### PR TITLE
spec: add snapshot-engine v1 + Mali-pense source registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 app description.txt
 design.txt
 cursor_project_requirements_and_design.md
+Misc/
 
 # OS / editor
 .DS_Store

--- a/shared/sources/README.md
+++ b/shared/sources/README.md
@@ -1,0 +1,56 @@
+# Source Registry entries
+
+This directory contains **source registry entries** (YAML files) for each data source Nkokan ingests.
+
+See `shared/specs/source-registry.md` for field definitions and requirements.
+
+## Files
+
+- `malipense.yaml` — Mali-pense / Malidaba French → Maninka dictionary (Phase 1 primary source)
+
+## Adding a new source
+
+1. Create a new YAML file named after the source (e.g., `newsource.yaml`).
+2. Include all required fields from `source-registry.md`.
+3. Set `contact_status: "not_attempted"` until outreach is done.
+4. Open a PR with the `data` and `sources` labels.
+
+## License status lifecycle
+
+Source entries MUST track license/permission status through these stages:
+
+| Status | Meaning |
+|--------|---------|
+| `unknown` | No license information found on site |
+| `claimed` | License text found on site (record `license_evidence_url`) |
+| `pending` | Outreach sent; awaiting response |
+| `confirmed` | Explicit permission received (record date + evidence) |
+| `denied` | Permission explicitly refused (do not ingest) |
+| `conditional` | Permission granted with conditions (document them) |
+
+After any outreach attempt:
+- Update `contact_status` to `attempted`, `responded`, `granted`, or `denied`
+- Update `contact_attempted_at` with the date
+- Add notes to `license_inference_note` documenting what was communicated
+
+## Legal/ethics review labels
+
+When opening PRs that affect source data or licensing:
+
+| Label | When to use |
+|-------|-------------|
+| `sources` | Any change to source registry entries |
+| `data` | Any change affecting ingested data |
+| `legal` | License questions, permission status changes, takedown requests |
+| `ethics-review` | Content that may have cultural sensitivity (consult before merging) |
+
+For PRs touching `legal` or `ethics-review`, request explicit maintainer sign-off before merging.
+
+## Removal / disable process
+
+If a source must be disabled:
+
+1. Set `disabled_at` to the current ISO-8601 timestamp.
+2. Set `disable_reason` explaining why (takedown request, license issue, etc.).
+3. Do NOT delete the file — keep it for audit trail.
+4. Open an issue using the "Data removal / source maintainer request" template.

--- a/shared/sources/malipense.yaml
+++ b/shared/sources/malipense.yaml
@@ -1,0 +1,77 @@
+# Mali-pense / Malidaba Source Registry Entry
+# See shared/specs/source-registry.md for field definitions
+
+source_id: src_malipense
+name: "Mali-pense / Malidaba French → Maninka dictionary"
+homepage_url: "https://www.mali-pense.net/"
+
+# Licensing (verified from site; redistribution confirmation pending)
+claimed_license: "CC BY-NC-SA 4.0 (Malidaba landing page claim; scope confirmation pending)"
+license_evidence_url: "https://www.mali-pense.net/emk/lexicon/index.htm"
+license_inference_note: |
+  The Malidaba dictionary landing page (license_evidence_url) states:
+    EN: "Malidaba dictionary is available under licence Creative Commons - CC BY-NC-SA 4.0 Deed…"
+    FR: "Le dictionnaire Malidaba est mis à disposition selon les termes de la licence Creative Commons … CC BY-NC-SA 4.0 Deed…"
+  
+  Important: This license claim is on the Malidaba landing page. It does not automatically
+  prove that all sub-areas or older pages (e.g., /emk/index-french/) are under the same license.
+  
+  Status: Explicit CC BY-NC-SA 4.0 claim exists. Confirmation pending for:
+    - Scope: does the license cover /emk/index-french/ pages?
+    - Redistribution: is offline bundling permitted under CC BY-NC-SA 4.0?
+    - Attribution: what attribution text is required?
+
+redistribution_policy: "unknown"
+
+# Takedown / removal
+takedown_policy_ref: |
+  Use GitHub issue template "Data removal / source maintainer request".
+  Or contact maintainers via GitHub or the emails below.
+
+# Contacts (verified from https://www.mali-pense.net/Pour-nous-joindre.html)
+contacts:
+  - name: "Dramane SIMAGA"
+    email: "dra@mali-pense.net"
+    role: "maintainer"
+  - name: "Jean-Jacques MÉRIC"
+    email: "jj@mali-pense.net"
+    role: "maintainer"
+  - name: "General contact"
+    email: "contact@mali-pense.net"
+    role: "general"
+    notes: "Historical reliability issues noted on contact page; may intermittently fail."
+
+contact_page_url: "https://www.mali-pense.net/Pour-nous-joindre.html"
+contact_status: "not_attempted"
+contact_attempted_at: null
+
+# Crawl targets (verified structure)
+index_url_pattern: "/emk/index-french/{letter}.htm"
+index_url_example: "https://www.mali-pense.net/emk/index-french/h.htm"
+
+crawl_notes: |
+  Index pages: /emk/index-french/{letter}.htm (a.htm through z.htm, possibly with gaps)
+  Entry structure: HTML with dictionary entries (structure TBD during prototype crawl)
+  Encoding: likely iso-8859-1 or windows-1252 (verify during crawl)
+  
+  Note: Do NOT use /Lexique-Maninka/ paths — that's a different/older area.
+
+# Robots.txt override (only set true if explicit permission obtained)
+permission_override: false
+
+# Disable controls
+disabled_at: null
+disable_reason: null
+
+# Record identity notes
+record_identity_notes: |
+  Entries are on per-letter index pages (/emk/index-french/a.htm, b.htm, etc.).
+  No stable per-entry URLs observed; use url_canonical + entry_index for identity.
+  Canonicalization: normalize https, lowercase host, no trailing slash.
+
+# Attribution template (pending confirmation of required format)
+attribution_template: |
+  Source: Mali-pense / Malidaba French → Maninka dictionary
+  License: CC BY-NC-SA 4.0 (pending scope confirmation)
+  URL: https://www.mali-pense.net/
+  Retrieved: {retrieved_at}

--- a/shared/specs/snapshot-engine.md
+++ b/shared/specs/snapshot-engine.md
@@ -1,0 +1,305 @@
+# Snapshot Engine specification (v1)
+
+This document defines **crawler/capture behavior** for the Nkokan Snapshot Engine.
+
+It complements `lossless-capture-and-ir.md` (which defines snapshot **data contracts**) by specifying how the engine **operates**: idempotency, politeness, storage layout, and change detection.
+
+It is **stack-neutral**: it defines behavioral requirements, not implementation language or storage backend.
+
+## Why this exists
+
+Old sites die. Links rot. Character encoding quirks become impossible to debug without raw evidence.
+
+**"Snapshot first"** is the only posture that prevents catastrophic dependency on fragile external hosts.
+
+## Goals
+
+- **Idempotent**: re-running the engine produces the same outcome without duplication or data loss.
+- **Evidence-preserving**: store enough metadata to resolve future encoding/content disputes.
+- **Polite**: respect target servers; do not cause outages or get blocked.
+- **Incremental**: support partial crawls and resumption.
+- **Change-aware**: detect content changes across crawl runs, including reverts (A→B→A).
+
+## Non-goals
+
+- Parsing HTML into structured records (that's Phase 1.2 / IR).
+- Defining full storage technology (local files vs object store vs DB).
+- Defining normalization or transliteration rules.
+
+---
+
+## Snapshot output contract (per page)
+
+Each captured page MUST produce a snapshot record with:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `snapshot_id` | ✅ | Deterministic identifier (see computation rule below) |
+| `source_id` | ✅ | Stable join key from Source Registry |
+| `url_original` | ✅ | URL as requested |
+| `url_canonical` | ✅ | URL after redirect resolution + canonicalization |
+| `url_canonicalization_version` | ✅ | Version of canonicalization rules applied |
+| `retrieved_at` | ✅ | ISO-8601 timestamp (UTC, second precision) |
+| `http_status` | ✅ | Numeric HTTP status code |
+| `headers` | ✅ | Full response headers (after redaction; see below) |
+| `content_sha256` | ✅ | SHA-256 hash of raw response body bytes (hex, lowercase) |
+| `byte_length` | ✅ | Size of raw body in bytes |
+| `payload_path` | ✅ | Path/key to compressed payload file |
+| `robots_observed` | ✅ | `true` if robots.txt was checked; `false` otherwise |
+| `robots_policy_notes` | Recommended | Notes on robots.txt status (allowed/disallowed/no-robots-file) |
+| `encoding` | Recommended | Declared or detected character encoding |
+| `content_type` | Recommended | Content-Type header value |
+| `redirect_chain` | Recommended | Array of redirect hops `[{status, url}, ...]` if any |
+| `crawl_id` | Recommended | Identifier for the crawl batch/run |
+| `fetch_tool_version` | Recommended | Version of the crawler/engine |
+
+### `snapshot_id` computation (normative)
+
+To prevent divergence across implementations, `snapshot_id` MUST be computed deterministically:
+
+```
+snapshot_id = sha256_hex(url_canonical + "\n" + retrieved_at + "\n" + content_sha256)[:16]
+```
+
+Where:
+- `url_canonical` is the canonicalized URL (string)
+- `retrieved_at` is the ISO-8601 timestamp in UTC with second precision (e.g., `2026-01-15T14:30:00Z`)
+- `content_sha256` is the lowercase hex SHA-256 of the raw response body
+- `sha256_hex(...)` computes SHA-256 and returns lowercase hex
+- `[:16]` truncates to the first 16 hex characters
+
+This produces a unique identifier per fetch event: same content fetched at different times yields different `snapshot_id` values.
+
+### Payload storage
+
+- Raw response body MUST be stored as compressed bytes (`.html.zst` recommended; `.html.gz` acceptable).
+- Payload files MUST be immutable once written.
+- Payload filename SHOULD include `snapshot_id` or `content_sha256` for traceability.
+
+### Header redaction (required)
+
+Before persisting headers, the engine MUST apply a redaction policy:
+
+**MUST redact** (remove entirely or replace with `[REDACTED]`):
+- `Set-Cookie`, `Cookie`
+- `Authorization`, `Proxy-Authorization`
+- Any header containing tokens, session IDs, or credentials
+
+**SHOULD preserve** (for debugging/evidence):
+- `Content-Type`, `Content-Length`, `Content-Encoding`
+- `Last-Modified`, `ETag`
+- `X-*` headers (unless they contain credentials)
+- `Server`, `Date`
+
+Record `redaction_policy_id` (e.g., `"header_redact_v1"`) on the snapshot metadata.
+
+---
+
+## Idempotency requirements
+
+The engine MUST be idempotent:
+
+1. **Skip if unchanged**: If the content hash of a newly fetched page matches an existing snapshot for the same `url_canonical`, do NOT create a new snapshot. Instead, record the match in `crawl_results.jsonl` (see below).
+
+2. **Never overwrite**: Existing snapshots are immutable. A changed page produces a **new** snapshot (new `snapshot_id`, new `retrieved_at`), not an update.
+
+3. **Track status**: For each URL in a crawl run, record one of:
+   - `new` — no prior snapshot for this `url_canonical`; new snapshot created
+   - `changed` — content hash differs from latest snapshot; new snapshot created
+   - `unchanged` — content hash matches latest snapshot; no new snapshot created
+   - `error` — fetch failed (record HTTP status or exception)
+   - `robots_blocked` — fetch skipped due to robots.txt disallow (see Politeness)
+
+4. **Resumable**: If a crawl is interrupted, re-running SHOULD resume from where it left off (skip already-captured URLs in the current batch).
+
+### Timeline preservation (A→B→A scenario)
+
+To support detecting content that changes and then reverts (A→B→A), the engine MUST record every URL check in `crawl_results.jsonl`, even when no new payload is stored.
+
+This ensures:
+- Crawl 1: Store snapshot with hash A → status `new`
+- Crawl 2: Store snapshot with hash B → status `changed`
+- Crawl 3: No new snapshot (matches A) → status `unchanged`, `matched_snapshot_id` points to original
+
+The timeline is preserved in the crawl results, not just the snapshot store.
+
+---
+
+## Politeness requirements
+
+The engine MUST be polite to target servers:
+
+| Requirement | Default | Notes |
+|-------------|---------|-------|
+| **Single-threaded** | Yes | No parallel requests to the same host |
+| **Request delay** | ≥ 2 seconds | Between consecutive requests to same host |
+| **User-Agent** | Descriptive | Include project name + contact (e.g., `Nkokan-Snapshot/1.0 (+https://github.com/bohkelen/nkokan)`) |
+| **Retry with backoff** | Yes | On 429/5xx, exponential backoff (max 3 retries) |
+| **Abort on block** | Yes | If server returns persistent 403/429, stop crawl for that source and alert |
+
+### Robots.txt handling (normative)
+
+The engine MUST respect robots.txt with the following behavior:
+
+1. **Default action when disallowed**: If robots.txt disallows the URL for our User-Agent, **do not fetch** unless the Source Registry entry includes `permission_override: true`.
+
+2. **Recording**: Every snapshot MUST include:
+   - `robots_observed: true|false` — whether robots.txt was checked
+   - `robots_policy_notes` — one of:
+     - `"allowed"` — robots.txt permits access
+     - `"disallowed"` — robots.txt forbids access (should not have fetched unless override)
+     - `"no_robots_file"` — no robots.txt found (404 or empty)
+     - `"permission_override"` — fetched despite disallow due to explicit permission
+
+3. **No hard-fail on missing**: If robots.txt returns 404 or is unreachable, proceed with fetch and record `"no_robots_file"`.
+
+---
+
+## Required crawl artifacts (per `crawl_id`)
+
+Each crawl run MUST produce **two** artifact files:
+
+### 1. `snapshots.jsonl`
+
+One JSON object per line for each **new snapshot created** during this crawl.
+
+Contains full snapshot metadata (all required fields from the output contract).
+
+### 2. `crawl_results.jsonl`
+
+One JSON object per line for **every URL checked** during this crawl, regardless of whether a new snapshot was created.
+
+Required fields:
+
+| Field | Description |
+|-------|-------------|
+| `url_canonical` | Canonicalized URL |
+| `crawl_status` | One of: `new`, `changed`, `unchanged`, `error`, `robots_blocked` |
+| `checked_at` | ISO-8601 timestamp of when this URL was checked |
+| `snapshot_id` | If `new` or `changed`: the new snapshot's ID. If `unchanged`: the matched existing snapshot's ID. |
+| `content_sha256` | Hash of fetched content (if fetched) |
+| `error_details` | If `error`: HTTP status or exception message |
+
+This file enables:
+- Timeline reconstruction (A→B→A detection)
+- Crawl coverage verification
+- Resumption after interruption
+
+---
+
+## Storage layout (reference)
+
+This spec does not mandate a specific layout, but implementations MUST ensure:
+
+1. Given a `snapshot_id`, the payload is locatable.
+2. Given a `crawl_id`, both `snapshots.jsonl` and `crawl_results.jsonl` are locatable.
+
+Recommended structure:
+
+```
+data/
+  snapshots/
+    {source_id}/
+      {crawl_id}/
+        snapshots.jsonl           # new snapshot metadata
+        crawl_results.jsonl       # all URL check results
+        payloads/
+          {snapshot_id}.html.zst
+```
+
+Or content-addressed payloads:
+
+```
+data/
+  snapshots/
+    {source_id}/
+      crawls/
+        {crawl_id}/
+          snapshots.jsonl
+          crawl_results.jsonl
+      payloads/
+        {content_sha256_prefix}/{content_sha256}.html.zst
+```
+
+---
+
+## Crawl execution strategy (recommended)
+
+### Phase 1.1 execution order
+
+1. **Prototype crawl** — Capture a single index page (e.g., `/emk/index-french/a.htm`) + a handful of linked entry pages.
+   - Validate: encoding detection, link discovery, canonicalization, storage layout.
+   - Fix any spec/implementation issues before proceeding.
+
+2. **Expand** — Crawl all A–Z index pages with rate limiting.
+   - Produce a manifest of all entry URLs discovered.
+
+3. **Entry crawl** — Crawl all discovered entry pages.
+   - Apply idempotency (skip if already captured with same hash).
+
+4. **Re-crawl (later)** — Periodic re-crawl with unchanged/changed/new accounting.
+
+---
+
+## Success conditions (Phase 1.1 DoD)
+
+Phase 1.1 is complete when:
+
+- [ ] **Rebuild independence**: Any downstream parse can be executed without re-fetching from the source website.
+- [ ] **Change detection**: Re-running the crawl detects unchanged/changed/new pages by hash comparison, with timeline preserved in `crawl_results.jsonl`.
+- [ ] **Evidence sufficiency**: Stored headers + raw bytes are sufficient to resolve future encoding/content disputes.
+- [ ] **Idempotency verified**: Re-running the engine on the same URL set produces no duplicate snapshots.
+- [ ] **Two-artifact compliance**: Each crawl produces both `snapshots.jsonl` and `crawl_results.jsonl`.
+
+---
+
+## Relationship to other specs
+
+| Spec | Relationship |
+|------|--------------|
+| `lossless-capture-and-ir.md` | Defines snapshot **data fields**; this spec defines **engine behavior** |
+| `source-registry.md` | Engine MUST reference `source_id` from the registry; check `permission_override` for robots bypass |
+| `provenance.md` | Downstream IR/records will reference `snapshot_id` from engine output |
+
+---
+
+## Normative example: snapshot record
+
+```json
+{
+  "snapshot_id": "a1b2c3d4e5f67890",
+  "source_id": "src_malipense",
+  "url_original": "https://www.mali-pense.net/emk/index-french/a.htm",
+  "url_canonical": "https://www.mali-pense.net/emk/index-french/a.htm",
+  "url_canonicalization_version": "urlcanon_v1",
+  "retrieved_at": "2026-01-15T14:30:00Z",
+  "http_status": 200,
+  "headers": {
+    "Content-Type": "text/html; charset=iso-8859-1",
+    "Last-Modified": "Sun, 01 Jan 2023 00:00:00 GMT",
+    "Content-Length": "45678"
+  },
+  "content_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "byte_length": 45678,
+  "payload_path": "payloads/a1b2c3d4e5f67890.html.zst",
+  "encoding": "iso-8859-1",
+  "redirect_chain": [],
+  "crawl_id": "crawl_2026-01-15_malipense_v1",
+  "fetch_tool_version": "nkokan-snapshot/0.1.0",
+  "redaction_policy_id": "header_redact_v1",
+  "robots_observed": true,
+  "robots_policy_notes": "allowed"
+}
+```
+
+## Normative example: crawl result entry (unchanged)
+
+```json
+{
+  "url_canonical": "https://www.mali-pense.net/emk/index-french/a.htm",
+  "crawl_status": "unchanged",
+  "checked_at": "2026-02-01T10:00:00Z",
+  "snapshot_id": "a1b2c3d4e5f67890",
+  "content_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+}
+```


### PR DESCRIPTION
Phase 1.1 foundation:

- shared/specs/snapshot-engine.md: Crawler behavior spec
  - snapshot_id computation rule (deterministic: sha256 of url+timestamp+hash)
  - Idempotency requirements (skip-if-unchanged, never overwrite)
  - Timeline preservation (A→B→A via crawl_results.jsonl)
  - Two-artifact requirement: snapshots.jsonl + crawl_results.jsonl
  - Robots.txt handling (default: do not fetch if disallowed)
  - Politeness requirements (single-threaded, delay, user-agent)
  - Success conditions / DoD for Phase 1.1

- shared/sources/malipense.yaml: Source registry entry
  - CC BY-NC-SA 4.0 license claim (verified from Malidaba landing page)
  - Verified contacts (Dramane SIMAGA, Jean-Jacques MÉRIC)
  - Correct URL pattern: /emk/index-french/{letter}.htm
  - Conservative redistribution stance (scope confirmation pending)

- shared/sources/README.md: Governance improvements
  - License status lifecycle documentation
  - Legal/ethics review label guidance
  - Removal/disable process

- .gitignore: Add Misc/ to ignored paths

Closes Phase 0 spec work; unblocks Phase 1.1 crawler implementation.

## What does this PR change?

- 

## Why?

- 

## Checklist (required)

- [ ] I kept this PR narrowly scoped.
- [ ] If I changed language data / meaning, I explained the impact and any uncertainty.
- [ ] If this touches third-party sources, I preserved attribution and did not add content without permission.
- [ ] If this changes normalization/transliteration behavior, I added examples (inputs → outputs) in the PR description.

## Screenshots / notes (if applicable)

- 

