### PR TITLE
fix(crawler): add NOT_FOUND status for 404 responses

### DIFF
--- a/api/snapshot_engine/cli.py
+++ b/api/snapshot_engine/cli.py
@@ -152,7 +152,7 @@ Examples:
     )
 
     # Run crawler
-    stats = {"new": 0, "changed": 0, "unchanged": 0, "error": 0, "robots_blocked": 0}
+    stats = {"new": 0, "changed": 0, "unchanged": 0, "not_found": 0, "error": 0, "robots_blocked": 0}
 
     with SnapshotCrawler(config) as crawler:
         for result in crawler.crawl_urls(urls):
@@ -164,6 +164,7 @@ Examples:
     logger.info(f"  New:            {stats['new']}")
     logger.info(f"  Changed:        {stats['changed']}")
     logger.info(f"  Unchanged:      {stats['unchanged']}")
+    logger.info(f"  Not found:      {stats['not_found']}")
     logger.info(f"  Errors:         {stats['error']}")
     logger.info(f"  Robots blocked: {stats['robots_blocked']}")
     logger.info(f"Output: {config.output_dir / config.source_id / config.crawl_id}")

--- a/api/snapshot_engine/crawler.py
+++ b/api/snapshot_engine/crawler.py
@@ -238,6 +238,19 @@ class SnapshotCrawler:
             self._append_result(result)
             return result
 
+        # Handle 404 as a first-class outcome (page doesn't exist, not an error)
+        if response.status_code == 404:
+            logger.info(f"Not found (404): {url}")
+            result = CrawlResult(
+                url_canonical=url_canonical,
+                crawl_status=CrawlStatus.NOT_FOUND,
+                checked_at=checked_at,
+                error_details="http_404",
+            )
+            self._append_result(result)
+            return result
+
+        # Other 4xx/5xx are actual errors
         if response.status_code >= 400:
             result = CrawlResult(
                 url_canonical=url_canonical,

--- a/api/snapshot_engine/models.py
+++ b/api/snapshot_engine/models.py
@@ -21,7 +21,8 @@ class CrawlStatus(str, Enum):
     NEW = "new"  # No prior snapshot; new snapshot created
     CHANGED = "changed"  # Content hash differs; new snapshot created
     UNCHANGED = "unchanged"  # Content hash matches; no new snapshot
-    ERROR = "error"  # Fetch failed
+    NOT_FOUND = "not_found"  # HTTP 404 - page doesn't exist (valid state, not error)
+    ERROR = "error"  # Fetch failed (network error, 5xx, max retries)
     ROBOTS_BLOCKED = "robots_blocked"  # Skipped due to robots.txt
 
 


### PR DESCRIPTION
404 is now a first-class crawl outcome, distinct from ERROR:
- CrawlStatus.NOT_FOUND for HTTP 404 (valid state: page doesn't exist)
- CrawlStatus.ERROR for network failures, 5xx, etc.

This prevents noisy error counts when crawling pages that legitimately don't exist (e.g., x.htm for French index, z.htm for Maninka lexicon).

## What does this PR change?

- 

## Why?

- 

## Checklist (required)

- [ ] I kept this PR narrowly scoped.
- [ ] If I changed language data / meaning, I explained the impact and any uncertainty.
- [ ] If this touches third-party sources, I preserved attribution and did not add content without permission.
- [ ] If this changes normalization/transliteration behavior, I added examples (inputs → outputs) in the PR description.

## Screenshots / notes (if applicable)

- 

