### PR TITLE
feat(ir): implement Phase 1.2 IR parser and schema

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -57,9 +57,65 @@ data/snapshots/
 
 See `shared/specs/snapshot-engine.md` for full specification.
 
-## Planned responsibilities (Phase 1+)
+## IR Parser (Phase 1.2)
 
-- Ingestion pipeline entry points (raw capture → lossless IR → normalized records)
+The IR Parser extracts structured IR (Intermediate Representation) units from raw snapshots. IR preserves all source data in a lossless-enough format for downstream normalization.
+
+### Usage
+
+```bash
+# Parse all lexicon snapshots from a crawl
+nkokan-parse-ir --crawl-dir data/snapshots/src_malipense/crawl_xxx \
+    --output data/ir/malipense_lexicon.jsonl
+
+# With verbose logging
+nkokan-parse-ir --crawl-dir data/snapshots/src_malipense/crawl_xxx \
+    --output data/ir/malipense_lexicon.jsonl -v
+```
+
+### Output structure
+
+```
+data/ir/
+  malipense_lexicon.jsonl   # One IR unit per line (JSONL)
+```
+
+### IR unit shape
+
+```json
+{
+  "ir_id": "a7b3c9d2...",           // Deterministic, collision-safe
+  "ir_kind": "lexicon_entry",       // Document type
+  "source_id": "src_malipense",
+  "parser_version": "malipense_lexicon_v1",
+  "evidence": [{                    // Full entry block coverage
+    "source_id": "src_malipense",
+    "snapshot_id": "20f263ef...",
+    "entry_block": {...},
+    "text_quote": "ábadàn"
+  }],
+  "record_locator": {...},          // Identity hint
+  "fields_raw": {                   // Literal extraction
+    "headword_latin": "ábadàn",
+    "headword_nko_provided": "...",
+    "senses": [...]
+  }
+}
+```
+
+### Key design decisions
+
+- **`ir_id`**: Deterministic hash of `source_id|url_canonical|record_id|parser_version`
+- **No `retrieved_at`**: Join via `snapshot_id` instead
+- **Evidence covers full block**: Not just headword element
+- **Literal extraction**: `ps_raw` preserved verbatim, `pos_hint` only if confident
+- **"Provided" forms**: N'Ko from source stored as `headword_nko_provided`
+
+See `shared/specs/lossless-capture-and-ir.md` for full specification.
+
+## Planned responsibilities (Phase 1.3+)
+
+- Normalization pipeline (IR → normalized lexicon records)
 - Provenance enforcement (entry/sense/example)
 - Transliteration service/module hooks (Latin → N'Ko + uncertainty flags)
 - Moderation queue for anonymous suggestions (audit + rollback)

--- a/api/ir_parser/__init__.py
+++ b/api/ir_parser/__init__.py
@@ -1,0 +1,12 @@
+"""
+IR Parser module for Nkokan.
+
+Parsers extract IR units from raw snapshots.
+"""
+
+from .malipense_lexicon import MalipenseLexiconParser, PARSER_VERSION
+
+__all__ = [
+    "MalipenseLexiconParser",
+    "PARSER_VERSION",
+]

--- a/api/ir_parser/cli.py
+++ b/api/ir_parser/cli.py
@@ -1,0 +1,174 @@
+"""
+CLI for IR parser.
+
+Processes snapshots and outputs IR JSONL.
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import zstandard as zstd
+
+# Add shared to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "shared"))
+
+from .malipense_lexicon import MalipenseLexiconParser, PARSER_VERSION
+
+logger = logging.getLogger(__name__)
+
+
+def load_snapshots_metadata(jsonl_path: Path) -> dict[str, dict]:
+    """Load snapshot metadata from snapshots.jsonl."""
+    metadata = {}
+    with open(jsonl_path, "r", encoding="utf-8") as f:
+        for line in f:
+            record = json.loads(line)
+            snapshot_id = record.get("snapshot_id")
+            if snapshot_id:
+                metadata[snapshot_id] = record
+    return metadata
+
+
+def process_lexicon_crawl(
+    crawl_dir: Path,
+    output_path: Path,
+    verbose: bool = False,
+) -> dict[str, int]:
+    """
+    Process all lexicon snapshots from a crawl directory.
+    
+    Args:
+        crawl_dir: Path to crawl directory (contains payloads/ and snapshots.jsonl)
+        output_path: Path to output IR JSONL file
+        verbose: Whether to print progress
+    
+    Returns:
+        Stats dict with counts
+    """
+    payloads_dir = crawl_dir / "payloads"
+    snapshots_jsonl = crawl_dir / "snapshots.jsonl"
+    
+    if not payloads_dir.exists():
+        raise FileNotFoundError(f"Payloads directory not found: {payloads_dir}")
+    if not snapshots_jsonl.exists():
+        raise FileNotFoundError(f"Snapshots JSONL not found: {snapshots_jsonl}")
+    
+    # Load snapshot metadata
+    metadata = load_snapshots_metadata(snapshots_jsonl)
+    
+    stats = {
+        "snapshots_processed": 0,
+        "snapshots_skipped": 0,
+        "entries_parsed": 0,
+        "entries_with_warnings": 0,
+        "parse_errors": 0,
+    }
+    
+    dctx = zstd.ZstdDecompressor()
+    
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    with open(output_path, "w", encoding="utf-8") as out_f:
+        for payload_path in sorted(payloads_dir.glob("*.html.zst")):
+            snapshot_id = payload_path.name.replace(".html.zst", "")
+            
+            if snapshot_id not in metadata:
+                logger.warning(f"Snapshot {snapshot_id} not found in metadata, skipping")
+                stats["snapshots_skipped"] += 1
+                continue
+            
+            meta = metadata[snapshot_id]
+            url_canonical = meta.get("url_canonical", "")
+            
+            # Only process lexicon pages
+            if "/emk/lexicon/" not in url_canonical:
+                if verbose:
+                    logger.info(f"Skipping non-lexicon page: {url_canonical}")
+                stats["snapshots_skipped"] += 1
+                continue
+            
+            if verbose:
+                logger.info(f"Processing: {url_canonical}")
+            
+            try:
+                # Decompress
+                with open(payload_path, "rb") as f:
+                    html_content = dctx.decompress(f.read())
+                
+                # Parse
+                parser = MalipenseLexiconParser(snapshot_id, url_canonical)
+                
+                for ir_unit in parser.parse_html(html_content):
+                    out_f.write(json.dumps(ir_unit.to_dict(), ensure_ascii=False) + "\n")
+                    stats["entries_parsed"] += 1
+                    
+                    if ir_unit.parse_warnings:
+                        stats["entries_with_warnings"] += 1
+                
+                stats["snapshots_processed"] += 1
+                
+            except Exception as e:
+                logger.error(f"Error processing {payload_path}: {e}")
+                stats["parse_errors"] += 1
+    
+    return stats
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Parse Mali-pense lexicon snapshots into IR JSONL"
+    )
+    parser.add_argument(
+        "--crawl-dir",
+        type=Path,
+        required=True,
+        help="Path to crawl directory (contains payloads/ and snapshots.jsonl)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Output IR JSONL file path",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Verbose output",
+    )
+    
+    args = parser.parse_args()
+    
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(levelname)s: %(message)s",
+    )
+    
+    print(f"Processing crawl: {args.crawl_dir}")
+    print(f"Parser version: {PARSER_VERSION}")
+    print()
+    
+    stats = process_lexicon_crawl(
+        args.crawl_dir,
+        args.output,
+        verbose=args.verbose,
+    )
+    
+    print()
+    print("=" * 50)
+    print("IR Parser Results")
+    print("=" * 50)
+    print(f"Snapshots processed:     {stats['snapshots_processed']}")
+    print(f"Snapshots skipped:       {stats['snapshots_skipped']}")
+    print(f"Entries parsed:          {stats['entries_parsed']}")
+    print(f"Entries with warnings:   {stats['entries_with_warnings']}")
+    print(f"Parse errors:            {stats['parse_errors']}")
+    print(f"Output: {args.output}")
+    print("=" * 50)
+
+
+if __name__ == "__main__":
+    main()

--- a/api/ir_parser/malipense_lexicon.py
+++ b/api/ir_parser/malipense_lexicon.py
@@ -1,0 +1,535 @@
+"""
+Mali-pense lexicon page parser.
+
+Parses /emk/lexicon/{letter}.htm pages into IR units.
+
+HTML structure (observed 2026-01-22):
+    <a name="ábadàn"></a><a name="abadan"></a>
+    <p class="lxP">
+        <span id="e15" class="Lxe">ábadàn</span>     <!-- Headword -->
+        <span class="GlNko">ߤߓߊߘߊ߲߫</span>           <!-- N'Ko (provided) -->
+        <span class="PS">adv jamais</span>           <!-- POS + gloss hint -->
+        ...
+    </p>
+    <p class="lxP2">                                 <!-- Sense/example blocks -->
+        <span class="SnsN">1 • </span>
+        <div class="GlFr">jamais</div>
+        <div class="GlEn">never</div>
+        <span class="Exe">...</span>                 <!-- Example -->
+        ...
+    </p>
+    <!-- More lxP2 blocks until next lxP -->
+
+Entry boundary rule: from <p class="lxP"> containing <span id="eN"> 
+                     until next <p class="lxP"> (exclusive)
+"""
+
+import json
+import logging
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+from bs4 import BeautifulSoup, Tag
+
+# Add shared to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "shared"))
+
+from ir.models import (
+    IRUnit,
+    IRKind,
+    EntryBlock,
+    EvidencePointer,
+    RecordLocator,
+    RecordLocatorKind,
+    LexiconEntryFieldsRaw,
+    SenseRaw,
+    ExampleRaw,
+    compute_ir_id,
+)
+
+logger = logging.getLogger(__name__)
+
+PARSER_VERSION = "malipense_lexicon_v1"
+SOURCE_ID = "src_malipense"
+
+
+@dataclass
+class ParsedEntry:
+    """Intermediate structure for a parsed entry before conversion to IR."""
+    entry_id: str  # e.g., "e15"
+    anchor_names: list[str]
+    headword_latin: str
+    headword_nko: str | None
+    ps_raw: str | None
+    pos_hint: str | None
+    senses: list[SenseRaw]
+    variants_raw: list[str]
+    synonyms_raw: list[str]
+    etymology_raw: str | None
+    literal_meaning_raw: str | None
+    corpus_count: int | None
+    warnings: list[str]
+
+
+class MalipenseLexiconParser:
+    """
+    Parser for Mali-pense lexicon pages.
+    
+    Extracts lexicon entries from /emk/lexicon/{letter}.htm pages.
+    """
+    
+    def __init__(self, snapshot_id: str, url_canonical: str):
+        """
+        Initialize parser for a specific snapshot.
+        
+        Args:
+            snapshot_id: The snapshot ID this parser is working on
+            url_canonical: Canonical URL of the page
+        """
+        self.snapshot_id = snapshot_id
+        self.url_canonical = url_canonical
+        self.parser_version = PARSER_VERSION
+        self.source_id = SOURCE_ID
+    
+    def parse_html(self, html_content: str | bytes) -> Iterator[IRUnit]:
+        """
+        Parse HTML content and yield IR units.
+        
+        Args:
+            html_content: Raw HTML content (str or bytes)
+        
+        Yields:
+            IRUnit for each entry found
+        """
+        if isinstance(html_content, bytes):
+            html_content = html_content.decode("utf-8", errors="replace")
+        
+        soup = BeautifulSoup(html_content, "html.parser")
+        
+        # Find all entry header paragraphs (p.lxP with span.Lxe)
+        entry_headers = soup.find_all("p", class_="lxP")
+        
+        for i, header in enumerate(entry_headers):
+            # Find the entry ID span
+            entry_span = header.find("span", class_="Lxe")
+            if not entry_span or not entry_span.get("id"):
+                continue
+            
+            entry_id = entry_span.get("id")
+            
+            # Determine entry block boundary (until next p.lxP)
+            next_header = entry_headers[i + 1] if i + 1 < len(entry_headers) else None
+            next_entry_id = None
+            if next_header:
+                next_span = next_header.find("span", class_="Lxe")
+                if next_span:
+                    next_entry_id = next_span.get("id")
+            
+            # Collect all elements for this entry
+            entry_elements = [header]
+            sibling = header.find_next_sibling()
+            while sibling:
+                if sibling.name == "p" and "lxP" in sibling.get("class", []):
+                    break  # Hit next entry
+                entry_elements.append(sibling)
+                sibling = sibling.find_next_sibling()
+            
+            # Parse the entry
+            try:
+                parsed = self._parse_entry(entry_id, entry_elements)
+                ir_unit = self._to_ir_unit(parsed, next_entry_id)
+                yield ir_unit
+            except Exception as e:
+                logger.warning(f"Failed to parse entry {entry_id}: {e}")
+                continue
+    
+    def _parse_entry(self, entry_id: str, elements: list[Tag]) -> ParsedEntry:
+        """Parse entry elements into intermediate structure."""
+        warnings: list[str] = []
+        
+        # First element is the header (p.lxP)
+        header = elements[0]
+        
+        # Extract anchor names (a[@name] before the header)
+        anchor_names = self._extract_anchor_names(header)
+        
+        # Extract headword (span.Lxe)
+        entry_span = header.find("span", class_="Lxe")
+        headword_latin = entry_span.get_text(strip=True) if entry_span else ""
+        
+        # Extract N'Ko (span.GlNko in header)
+        nko_span = header.find("span", class_="GlNko")
+        headword_nko = nko_span.get_text(strip=True) if nko_span else None
+        
+        # Extract PS line (span.PS) - DON'T over-interpret
+        ps_span = header.find("span", class_="PS")
+        ps_raw = ps_span.get_text(strip=True) if ps_span else None
+        pos_hint = self._extract_pos_hint(ps_raw) if ps_raw else None
+        
+        # Extract etymology (span.Mnhbw)
+        etymology_span = header.find("span", class_="Mnhbw")
+        etymology_raw = etymology_span.get_text(strip=True) if etymology_span else None
+        
+        # Extract literal meaning (span.lpLiteralMeaningEnglish or Mnhlitt)
+        literal_span = header.find("span", class_="lpLiteralMeaningEnglish")
+        if not literal_span:
+            literal_span = header.find("span", class_="Mnhlitt")
+        literal_meaning_raw = literal_span.get_text(strip=True) if literal_span else None
+        
+        # Extract corpus count (from the clnknt link)
+        corpus_count = self._extract_corpus_count(header)
+        
+        # Extract variants (span.Mnhvam, Mnhrv)
+        variants_raw = self._extract_variants(header)
+        
+        # Extract synonyms (span.Mnhsynm) from header
+        synonyms_raw = self._extract_synonyms(header)
+        
+        # Parse sense blocks (p.lxP2)
+        senses = self._parse_senses(elements[1:], warnings)
+        
+        return ParsedEntry(
+            entry_id=entry_id,
+            anchor_names=anchor_names,
+            headword_latin=headword_latin,
+            headword_nko=headword_nko,
+            ps_raw=ps_raw,
+            pos_hint=pos_hint,
+            senses=senses,
+            variants_raw=variants_raw,
+            synonyms_raw=synonyms_raw,
+            etymology_raw=etymology_raw,
+            literal_meaning_raw=literal_meaning_raw,
+            corpus_count=corpus_count,
+            warnings=warnings,
+        )
+    
+    def _extract_anchor_names(self, header: Tag) -> list[str]:
+        """Extract anchor names from <a name="..."> elements before the header."""
+        anchors = []
+        prev = header.find_previous_sibling()
+        while prev and prev.name == "a" and prev.get("name"):
+            anchors.insert(0, prev.get("name"))
+            prev = prev.find_previous_sibling()
+        return anchors
+    
+    def _extract_pos_hint(self, ps_raw: str) -> str | None:
+        """
+        Extract POS hint from ps_raw string.
+        
+        Only extract if confident (first word is a known POS tag).
+        """
+        known_pos = {
+            "n", "v", "adj", "adv", "intj", "conj", "prep", "pp", "prt",
+            "pers", "prn", "dtm", "num", "cop", "pm", "ptcp", "vq", "onomat",
+            "n.prop", "pers/pm", "adv.p"
+        }
+        
+        if not ps_raw:
+            return None
+        
+        # First word/token
+        first_word = ps_raw.split()[0].lower() if ps_raw.split() else ""
+        
+        # Check for compound POS like "pers/pm"
+        if "/" in first_word:
+            return first_word
+        
+        if first_word in known_pos:
+            return first_word
+        
+        return None
+    
+    def _extract_corpus_count(self, header: Tag) -> int | None:
+        """Extract corpus link count from clnknt element."""
+        clnknt = header.find("b", class_="clnknt")
+        if clnknt:
+            link = clnknt.find("a")
+            if link:
+                text = link.get_text(strip=True)
+                # Format: "→ 1234"
+                match = re.search(r"(\d+)", text)
+                if match:
+                    return int(match.group(1))
+        return None
+    
+    def _extract_variants(self, header: Tag) -> list[str]:
+        """Extract variant forms from Mnhvam and Mnhrv spans."""
+        variants = []
+        
+        # Mnhvam contains variant links
+        for vam in header.find_all("span", class_="Mnhvam"):
+            for link in vam.find_all("a", class_="MXRef"):
+                text = link.get_text(strip=True)
+                if text and text not in variants:
+                    variants.append(text)
+        
+        # Mnhrv is "main variant" reference
+        for rv in header.find_all("span", class_="Mnhrv"):
+            for link in rv.find_all("a", class_="MXRef"):
+                text = link.get_text(strip=True)
+                if text and text not in variants:
+                    variants.append(text)
+        
+        return variants
+    
+    def _extract_synonyms(self, element: Tag) -> list[str]:
+        """Extract synonyms from Mnhsynm span."""
+        synonyms = []
+        for synm in element.find_all("span", class_="Mnhsynm"):
+            for link in synm.find_all("a"):
+                text = link.get_text(strip=True)
+                if text and text not in synonyms:
+                    synonyms.append(text)
+            # Also get non-linked text (span.LexF)
+            for lexf in synm.find_all("span", class_="LexF"):
+                text = lexf.get_text(strip=True)
+                if text and text not in synonyms:
+                    synonyms.append(text)
+        return synonyms
+    
+    def _parse_senses(self, elements: list[Tag], warnings: list[str]) -> list[SenseRaw]:
+        """Parse sense blocks (p.lxP2 elements)."""
+        senses: list[SenseRaw] = []
+        current_sense: SenseRaw | None = None
+        
+        for elem in elements:
+            if not isinstance(elem, Tag):
+                continue
+            
+            if elem.name != "p" or "lxP2" not in elem.get("class", []):
+                continue
+            
+            # Check if this starts a new sense (has SnsN)
+            sense_num_span = elem.find("span", class_="SnsN")
+            if sense_num_span:
+                # Save previous sense
+                if current_sense:
+                    senses.append(current_sense)
+                
+                # Start new sense
+                sense_text = sense_num_span.get_text(strip=True)
+                sense_num = self._parse_sense_number(sense_text)
+                
+                current_sense = SenseRaw(sense_num=sense_num)
+            
+            if current_sense is None:
+                # First block without SnsN - create sense 0
+                current_sense = SenseRaw(sense_num=None)
+            
+            # Extract glosses
+            gloss_fr = elem.find("div", class_="GlFr")
+            if gloss_fr:
+                text = gloss_fr.get_text(strip=True)
+                if text:
+                    current_sense.gloss_fr = text
+            
+            gloss_en = elem.find("div", class_="GlEn")
+            if gloss_en:
+                text = gloss_en.get_text(strip=True)
+                if text:
+                    current_sense.gloss_en = text
+            
+            gloss_ru = elem.find("div", class_="GlRu")
+            if gloss_ru:
+                text = gloss_ru.get_text(strip=True)
+                if text:
+                    current_sense.gloss_ru = text
+            
+            # Extract examples
+            examples = self._parse_examples(elem)
+            current_sense.examples.extend(examples)
+            
+            # Extract synonyms at sense level
+            synonyms = self._extract_synonyms(elem)
+            for s in synonyms:
+                if s not in current_sense.synonyms_raw:
+                    current_sense.synonyms_raw.append(s)
+            
+            # Extract sub-entries (→ markers - MXRef spans)
+            sub_entry = elem.find("span", class_="MXRef")
+            if sub_entry and not elem.find("span", class_="SnsN"):
+                # This is a sub-entry definition
+                sub_text = sub_entry.get_text(strip=True)
+                sub_nko = elem.find("div", class_="GlNko")
+                sub_gloss_fr = gloss_fr.get_text(strip=True) if gloss_fr else None
+                sub_gloss_en = gloss_en.get_text(strip=True) if gloss_en else None
+                
+                current_sense.sub_entries.append({
+                    "text": sub_text,
+                    "nko": sub_nko.get_text(strip=True) if sub_nko else None,
+                    "gloss_fr": sub_gloss_fr,
+                    "gloss_en": sub_gloss_en,
+                })
+        
+        # Don't forget the last sense
+        if current_sense:
+            senses.append(current_sense)
+        
+        return senses
+    
+    def _parse_sense_number(self, text: str) -> int | None:
+        """Parse sense number from "1 • " or similar."""
+        match = re.search(r"(\d+)", text)
+        if match:
+            return int(match.group(1))
+        return None
+    
+    def _parse_examples(self, elem: Tag) -> list[ExampleRaw]:
+        """Parse example sentences from a sense block."""
+        examples = []
+        
+        for exe in elem.find_all("span", class_="Exe"):
+            text_latin = exe.get_text(strip=True)
+            if not text_latin:
+                continue
+            
+            # Extract source attribution [Author Name]
+            source_attr = None
+            attr_match = re.search(r"\[([^\]]+)\]", text_latin)
+            if attr_match:
+                source_attr = attr_match.group(0)
+                # Remove from text
+                text_latin = re.sub(r"\s*\[[^\]]+\]\s*", " ", text_latin).strip()
+            
+            # Find corresponding N'Ko (next GlNko div)
+            text_nko = None
+            nko_div = exe.find_next("div", class_="GlNko")
+            if nko_div:
+                text_nko = nko_div.get_text(strip=True)
+            
+            # Find translations (next GlFr, GlEn, GlRu divs)
+            trans_fr = None
+            trans_en = None
+            trans_ru = None
+            
+            # Look for translation divs after the example
+            next_elem = exe.find_next_sibling()
+            while next_elem:
+                if isinstance(next_elem, Tag):
+                    if next_elem.name == "span" and "Exe" in next_elem.get("class", []):
+                        break  # Hit next example
+                    if next_elem.name == "div":
+                        classes = next_elem.get("class", [])
+                        if "GlFr" in classes and not trans_fr:
+                            trans_fr = next_elem.get_text(strip=True)
+                        elif "GlEn" in classes and not trans_en:
+                            trans_en = next_elem.get_text(strip=True)
+                        elif "GlRu" in classes and not trans_ru:
+                            trans_ru = next_elem.get_text(strip=True)
+                next_elem = next_elem.find_next_sibling()
+            
+            examples.append(ExampleRaw(
+                text_latin=text_latin,
+                text_nko_provided=text_nko,
+                trans_fr=trans_fr,
+                trans_en=trans_en,
+                trans_ru=trans_ru,
+                source_attribution=source_attr,
+            ))
+        
+        return examples
+    
+    def _to_ir_unit(self, parsed: ParsedEntry, next_entry_id: str | None) -> IRUnit:
+        """Convert parsed entry to IR unit."""
+        # Create entry block
+        entry_block = EntryBlock(
+            start_selector=f"span#{parsed.entry_id}",
+            end_selector=f"span#{next_entry_id}" if next_entry_id else None,
+        )
+        
+        # Create fields_raw
+        fields_raw = LexiconEntryFieldsRaw(
+            headword_latin=parsed.headword_latin,
+            headword_nko_provided=parsed.headword_nko,
+            anchor_names=parsed.anchor_names,
+            ps_raw=parsed.ps_raw,
+            pos_hint=parsed.pos_hint,
+            senses=parsed.senses,
+            variants_raw=parsed.variants_raw,
+            synonyms_raw=parsed.synonyms_raw,
+            etymology_raw=parsed.etymology_raw,
+            literal_meaning_raw=parsed.literal_meaning_raw,
+            corpus_count=parsed.corpus_count,
+        )
+        
+        # Create IR unit using factory method
+        return IRUnit.create_lexicon_entry(
+            source_id=self.source_id,
+            url_canonical=self.url_canonical,
+            source_record_id=parsed.entry_id,
+            parser_version=self.parser_version,
+            snapshot_id=self.snapshot_id,
+            entry_block=entry_block,
+            fields_raw=fields_raw,
+            anchor_names=parsed.anchor_names,
+            text_quote=parsed.headword_latin,
+            parse_warnings=parsed.warnings,
+        )
+
+
+def parse_snapshot_file(
+    snapshot_path: Path,
+    snapshots_jsonl_path: Path,
+) -> Iterator[IRUnit]:
+    """
+    Parse a snapshot file and yield IR units.
+    
+    Args:
+        snapshot_path: Path to the .html.zst payload file
+        snapshots_jsonl_path: Path to snapshots.jsonl for metadata lookup
+    
+    Yields:
+        IRUnit for each entry
+    """
+    import zstandard as zstd
+    
+    # Read snapshot metadata
+    # Filename is like "20f263ef15dc6ae1.html.zst", need to strip both extensions
+    snapshot_id = snapshot_path.name.replace(".html.zst", "")
+    metadata = None
+    
+    with open(snapshots_jsonl_path, "r", encoding="utf-8") as f:
+        for line in f:
+            record = json.loads(line)
+            if record.get("snapshot_id") == snapshot_id:
+                metadata = record
+                break
+    
+    if not metadata:
+        raise ValueError(f"Snapshot {snapshot_id} not found in {snapshots_jsonl_path}")
+    
+    url_canonical = metadata["url_canonical"]
+    
+    # Decompress and parse
+    dctx = zstd.ZstdDecompressor()
+    with open(snapshot_path, "rb") as f:
+        html_content = dctx.decompress(f.read())
+    
+    parser = MalipenseLexiconParser(snapshot_id, url_canonical)
+    yield from parser.parse_html(html_content)
+
+
+if __name__ == "__main__":
+    # Quick test
+    import sys
+    
+    if len(sys.argv) < 3:
+        print("Usage: python malipense_lexicon.py <payload.html.zst> <snapshots.jsonl>")
+        sys.exit(1)
+    
+    logging.basicConfig(level=logging.INFO)
+    
+    snapshot_path = Path(sys.argv[1])
+    snapshots_jsonl = Path(sys.argv[2])
+    
+    count = 0
+    for ir_unit in parse_snapshot_file(snapshot_path, snapshots_jsonl):
+        count += 1
+        if count <= 3:
+            print(json.dumps(ir_unit.to_dict(), indent=2, ensure_ascii=False))
+    
+    print(f"\nTotal entries parsed: {count}")

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -7,6 +7,8 @@ dependencies = [
     "httpx>=0.27.0",
     "zstandard>=0.22.0",
     "pyyaml>=6.0",
+    "beautifulsoup4>=4.12.0",
+    "lxml>=5.0.0",
 ]
 
 [project.optional-dependencies]
@@ -17,6 +19,7 @@ dev = [
 
 [project.scripts]
 nkokan-crawl = "snapshot_engine.cli:main"
+nkokan-parse-ir = "ir_parser.cli:main"
 
 [tool.ruff]
 line-length = 100
@@ -26,7 +29,7 @@ target-version = "py310"
 select = ["E", "F", "I", "W"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["snapshot_engine"]
+packages = ["snapshot_engine", "ir_parser"]
 
 [build-system]
 requires = ["hatchling"]

--- a/shared/ir/__init__.py
+++ b/shared/ir/__init__.py
@@ -1,0 +1,35 @@
+"""
+IR (Intermediate Representation) models for Nkokan.
+
+These models implement the contracts defined in shared/specs/lossless-capture-and-ir.md v1.1.
+"""
+
+from .models import (
+    IRKind,
+    EntryBlock,
+    EvidencePointer,
+    RecordLocator,
+    RecordLocatorKind,
+    ExampleRaw,
+    SenseRaw,
+    LexiconEntryFieldsRaw,
+    IndexMappingFieldsRaw,
+    TargetEntry,
+    IRUnit,
+    compute_ir_id,
+)
+
+__all__ = [
+    "IRKind",
+    "EntryBlock",
+    "EvidencePointer",
+    "RecordLocator",
+    "RecordLocatorKind",
+    "ExampleRaw",
+    "SenseRaw",
+    "LexiconEntryFieldsRaw",
+    "IndexMappingFieldsRaw",
+    "TargetEntry",
+    "IRUnit",
+    "compute_ir_id",
+]

--- a/shared/ir/models.py
+++ b/shared/ir/models.py
@@ -1,0 +1,468 @@
+"""
+IR (Intermediate Representation) data models.
+
+Implements shared/specs/lossless-capture-and-ir.md v1.1.
+
+Key design decisions:
+- ir_id is deterministic and collision-safe (includes url_canonical)
+- No retrieved_at or source_name on IR (join via snapshot/source registry)
+- ir_kind discriminates document types (lexicon_entry vs index_mapping)
+- Evidence covers full entry block, not just headword
+- fields_raw preserves literal extraction (no over-interpretation)
+- "provided" vs "generated" forms are distinguished
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from hashlib import sha256
+from typing import Any
+
+
+class IRKind(str, Enum):
+    """Document type discriminator for IR units."""
+    
+    LEXICON_ENTRY = "lexicon_entry"  # Dictionary entry (headword + senses + examples)
+    INDEX_MAPPING = "index_mapping"  # French/English index → Maninka entry refs
+    METADATA_PAGE = "metadata_page"  # Landing/info pages
+
+
+class RecordLocatorKind(str, Enum):
+    """Record locator kind per spec."""
+    
+    SOURCE_RECORD_ID = "source_record_id"
+    URL_CANONICAL_ENTRY_INDEX = "url_canonical+entry_index"
+    CSS_SELECTOR_TEXT_QUOTE = "css_selector+text_quote"
+    PAGE_BBOX_BLOCK_INDEX = "page+bbox+block_index"
+
+
+@dataclass
+class EntryBlock:
+    """
+    Defines the DOM range for an entry block.
+    
+    Used in evidence pointers to cover the full entry, not just the headword.
+    """
+    start_selector: str  # e.g., "span#e15"
+    end_selector: str | None = None  # e.g., "span#e16" (next entry, exclusive)
+    block_selectors: list[str] | None = None  # Alternative: explicit list of selectors
+
+
+@dataclass
+class EvidencePointer:
+    """
+    Fragment pointer to source evidence.
+    
+    Must cover the full entry block, not just the headword element.
+    """
+    source_id: str
+    snapshot_id: str
+    
+    # For HTML entries: block range
+    entry_block: EntryBlock | None = None
+    
+    # Simple selectors (for non-block evidence)
+    css_selector: str | None = None
+    xpath: str | None = None
+    
+    # Anchor text for verification
+    text_quote: str | None = None
+    
+    # For PDF/scans
+    page_number: int | None = None
+    bbox: dict[str, float] | None = None  # {x, y, w, h}
+    rotation_degrees: int | None = None
+    
+    # Hash of the fragment content
+    fragment_hash: str | None = None
+    fragment_representation_kind: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict, omitting None values."""
+        result: dict[str, Any] = {
+            "source_id": self.source_id,
+            "snapshot_id": self.snapshot_id,
+        }
+        if self.entry_block:
+            result["entry_block"] = {
+                "start_selector": self.entry_block.start_selector,
+            }
+            if self.entry_block.end_selector:
+                result["entry_block"]["end_selector"] = self.entry_block.end_selector
+            if self.entry_block.block_selectors:
+                result["entry_block"]["block_selectors"] = self.entry_block.block_selectors
+        if self.css_selector:
+            result["css_selector"] = self.css_selector
+        if self.xpath:
+            result["xpath"] = self.xpath
+        if self.text_quote:
+            result["text_quote"] = self.text_quote
+        if self.page_number is not None:
+            result["page_number"] = self.page_number
+        if self.bbox:
+            result["bbox"] = self.bbox
+        if self.rotation_degrees is not None:
+            result["rotation_degrees"] = self.rotation_degrees
+        if self.fragment_hash:
+            result["fragment_hash"] = self.fragment_hash
+        if self.fragment_representation_kind:
+            result["fragment_representation_kind"] = self.fragment_representation_kind
+        return result
+
+
+@dataclass
+class RecordLocator:
+    """
+    Identity hint for a source record within a snapshot.
+    
+    url_canonical is REQUIRED on all kinds for global uniqueness
+    (source IDs like "e15" are page-scoped).
+    """
+    kind: RecordLocatorKind
+    url_canonical: str  # REQUIRED for global uniqueness
+    
+    # For kind=source_record_id
+    source_record_id: str | None = None
+    anchor_names: list[str] | None = None  # Human-friendly anchors
+    
+    # For kind=url_canonical+entry_index
+    entry_index: int | None = None
+    
+    # For kind=css_selector+text_quote
+    css_selector: str | None = None
+    text_quote: str | None = None
+    
+    # For kind=page+bbox+block_index
+    page_number: int | None = None
+    bbox: dict[str, float] | None = None
+    block_index: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        result: dict[str, Any] = {
+            "kind": self.kind.value,
+            "url_canonical": self.url_canonical,
+        }
+        if self.source_record_id:
+            result["source_record_id"] = self.source_record_id
+        if self.anchor_names:
+            result["anchor_names"] = self.anchor_names
+        if self.entry_index is not None:
+            result["entry_index"] = self.entry_index
+        if self.css_selector:
+            result["css_selector"] = self.css_selector
+        if self.text_quote:
+            result["text_quote"] = self.text_quote
+        if self.page_number is not None:
+            result["page_number"] = self.page_number
+        if self.bbox:
+            result["bbox"] = self.bbox
+        if self.block_index is not None:
+            result["block_index"] = self.block_index
+        return result
+
+
+# --- fields_raw schemas by ir_kind ---
+
+@dataclass
+class ExampleRaw:
+    """Raw example sentence with translations."""
+    text_latin: str
+    text_nko_provided: str | None = None  # From source (not generated)
+    trans_fr: str | None = None
+    trans_en: str | None = None
+    trans_ru: str | None = None
+    source_attribution: str | None = None  # e.g., "[Diane Mamadi]"
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"text_latin": self.text_latin}
+        if self.text_nko_provided:
+            result["text_nko_provided"] = self.text_nko_provided
+        if self.trans_fr:
+            result["trans_fr"] = self.trans_fr
+        if self.trans_en:
+            result["trans_en"] = self.trans_en
+        if self.trans_ru:
+            result["trans_ru"] = self.trans_ru
+        if self.source_attribution:
+            result["source_attribution"] = self.source_attribution
+        return result
+
+
+@dataclass
+class SenseRaw:
+    """Raw sense/meaning with glosses and examples."""
+    sense_num: int | None = None  # 1, 2, 3... or None if not numbered
+    gloss_fr: str | None = None
+    gloss_en: str | None = None
+    gloss_ru: str | None = None
+    examples: list[ExampleRaw] = field(default_factory=list)
+    usage_note: str | None = None
+    synonyms_raw: list[str] = field(default_factory=list)
+    
+    # Sub-entries (→ markers in Mali-pense)
+    sub_entries: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if self.sense_num is not None:
+            result["sense_num"] = self.sense_num
+        if self.gloss_fr:
+            result["gloss_fr"] = self.gloss_fr
+        if self.gloss_en:
+            result["gloss_en"] = self.gloss_en
+        if self.gloss_ru:
+            result["gloss_ru"] = self.gloss_ru
+        if self.examples:
+            result["examples"] = [e.to_dict() for e in self.examples]
+        if self.usage_note:
+            result["usage_note"] = self.usage_note
+        if self.synonyms_raw:
+            result["synonyms_raw"] = self.synonyms_raw
+        if self.sub_entries:
+            result["sub_entries"] = self.sub_entries
+        return result
+
+
+@dataclass
+class LexiconEntryFieldsRaw:
+    """
+    fields_raw schema for ir_kind=lexicon_entry.
+    
+    Preserves literal extraction - no over-interpretation.
+    """
+    headword_latin: str
+    headword_nko_provided: str | None = None  # From source, not generated
+    anchor_names: list[str] = field(default_factory=list)
+    
+    # POS: store literally, don't over-interpret
+    ps_raw: str | None = None  # Exactly as found (e.g., "adv jamais")
+    pos_hint: str | None = None  # Optional, only if parser is confident
+    
+    # Senses
+    senses: list[SenseRaw] = field(default_factory=list)
+    
+    # Variants and cross-references
+    variants_raw: list[str] = field(default_factory=list)
+    synonyms_raw: list[str] = field(default_factory=list)
+    
+    # Other raw fields
+    etymology_raw: str | None = None
+    literal_meaning_raw: str | None = None
+    corpus_count: int | None = None  # Link count to corpus
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "headword_latin": self.headword_latin,
+        }
+        if self.headword_nko_provided:
+            result["headword_nko_provided"] = self.headword_nko_provided
+        if self.anchor_names:
+            result["anchor_names"] = self.anchor_names
+        if self.ps_raw:
+            result["ps_raw"] = self.ps_raw
+        if self.pos_hint:
+            result["pos_hint"] = self.pos_hint
+        if self.senses:
+            result["senses"] = [s.to_dict() for s in self.senses]
+        if self.variants_raw:
+            result["variants_raw"] = self.variants_raw
+        if self.synonyms_raw:
+            result["synonyms_raw"] = self.synonyms_raw
+        if self.etymology_raw:
+            result["etymology_raw"] = self.etymology_raw
+        if self.literal_meaning_raw:
+            result["literal_meaning_raw"] = self.literal_meaning_raw
+        if self.corpus_count is not None:
+            result["corpus_count"] = self.corpus_count
+        return result
+
+
+@dataclass
+class TargetEntry:
+    """A target entry reference in an index mapping."""
+    lexicon_url: str  # Relative URL to lexicon page
+    anchor: str  # Anchor ID (e.g., "e504")
+    display_text: str  # Display text (e.g., "bàn")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "lexicon_url": self.lexicon_url,
+            "anchor": self.anchor,
+            "display_text": self.display_text,
+        }
+
+
+@dataclass
+class IndexMappingFieldsRaw:
+    """
+    fields_raw schema for ir_kind=index_mapping.
+    
+    Represents a French/English/etc. term mapping to Maninka entries.
+    """
+    source_term: str  # e.g., "abandonner"
+    source_lang: str  # e.g., "fr", "en", "ru"
+    target_entries: list[TargetEntry] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_term": self.source_term,
+            "source_lang": self.source_lang,
+            "target_entries": [t.to_dict() for t in self.target_entries],
+        }
+
+
+def compute_ir_id(
+    source_id: str,
+    url_canonical: str,
+    record_id_component: str,
+    parser_version: str,
+) -> str:
+    """
+    Compute ir_id per spec (collision-safe, deterministic).
+    
+    ir_id = sha256(source_id + "|" + url_canonical + "|" + record_id_component + "|" + parser_version)[:16]
+    
+    Args:
+        source_id: From Source Registry (e.g., "src_malipense")
+        url_canonical: Page URL (required for global uniqueness)
+        record_id_component: Page-scoped ID (e.g., "e15") or stringified entry_index
+        parser_version: Parser version string
+    
+    Returns:
+        16-character hex string
+    """
+    data = f"{source_id}|{url_canonical}|{record_id_component}|{parser_version}"
+    return sha256(data.encode("utf-8")).hexdigest()[:16]
+
+
+@dataclass
+class IRUnit:
+    """
+    A single IR unit representing one source record.
+    
+    Implements shared/specs/lossless-capture-and-ir.md v1.1.
+    """
+    ir_id: str
+    ir_kind: IRKind
+    source_id: str
+    parser_version: str
+    evidence: list[EvidencePointer]
+    record_locator: RecordLocator
+    fields_raw: LexiconEntryFieldsRaw | IndexMappingFieldsRaw | dict[str, Any]
+    parse_warnings: list[str] = field(default_factory=list)
+    
+    # OCR-specific (only for OCR-derived IR)
+    ocr_engine: str | None = None
+    ocr_version: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        result: dict[str, Any] = {
+            "ir_id": self.ir_id,
+            "ir_kind": self.ir_kind.value,
+            "source_id": self.source_id,
+            "parser_version": self.parser_version,
+            "evidence": [e.to_dict() for e in self.evidence],
+            "record_locator": self.record_locator.to_dict(),
+        }
+        
+        # Handle fields_raw based on type
+        if hasattr(self.fields_raw, "to_dict"):
+            result["fields_raw"] = self.fields_raw.to_dict()
+        else:
+            result["fields_raw"] = self.fields_raw
+        
+        if self.parse_warnings:
+            result["parse_warnings"] = self.parse_warnings
+        if self.ocr_engine:
+            result["ocr_engine"] = self.ocr_engine
+        if self.ocr_version:
+            result["ocr_version"] = self.ocr_version
+        
+        return result
+
+    @classmethod
+    def create_lexicon_entry(
+        cls,
+        source_id: str,
+        url_canonical: str,
+        source_record_id: str,
+        parser_version: str,
+        snapshot_id: str,
+        entry_block: EntryBlock,
+        fields_raw: LexiconEntryFieldsRaw,
+        anchor_names: list[str] | None = None,
+        text_quote: str | None = None,
+        parse_warnings: list[str] | None = None,
+    ) -> "IRUnit":
+        """
+        Factory method to create a lexicon entry IR unit with proper ir_id computation.
+        """
+        ir_id = compute_ir_id(source_id, url_canonical, source_record_id, parser_version)
+        
+        evidence = EvidencePointer(
+            source_id=source_id,
+            snapshot_id=snapshot_id,
+            entry_block=entry_block,
+            text_quote=text_quote,
+        )
+        
+        record_locator = RecordLocator(
+            kind=RecordLocatorKind.SOURCE_RECORD_ID,
+            url_canonical=url_canonical,
+            source_record_id=source_record_id,
+            anchor_names=anchor_names,
+        )
+        
+        return cls(
+            ir_id=ir_id,
+            ir_kind=IRKind.LEXICON_ENTRY,
+            source_id=source_id,
+            parser_version=parser_version,
+            evidence=[evidence],
+            record_locator=record_locator,
+            fields_raw=fields_raw,
+            parse_warnings=parse_warnings or [],
+        )
+
+    @classmethod
+    def create_index_mapping(
+        cls,
+        source_id: str,
+        url_canonical: str,
+        entry_index: int,
+        parser_version: str,
+        snapshot_id: str,
+        css_selector: str,
+        fields_raw: IndexMappingFieldsRaw,
+        text_quote: str | None = None,
+        parse_warnings: list[str] | None = None,
+    ) -> "IRUnit":
+        """
+        Factory method to create an index mapping IR unit.
+        """
+        ir_id = compute_ir_id(source_id, url_canonical, str(entry_index), parser_version)
+        
+        evidence = EvidencePointer(
+            source_id=source_id,
+            snapshot_id=snapshot_id,
+            css_selector=css_selector,
+            text_quote=text_quote,
+        )
+        
+        record_locator = RecordLocator(
+            kind=RecordLocatorKind.URL_CANONICAL_ENTRY_INDEX,
+            url_canonical=url_canonical,
+            entry_index=entry_index,
+        )
+        
+        return cls(
+            ir_id=ir_id,
+            ir_kind=IRKind.INDEX_MAPPING,
+            source_id=source_id,
+            parser_version=parser_version,
+            evidence=[evidence],
+            record_locator=record_locator,
+            fields_raw=fields_raw,
+            parse_warnings=parse_warnings or [],
+        )

--- a/shared/specs/lossless-capture-and-ir.md
+++ b/shared/specs/lossless-capture-and-ir.md
@@ -1,4 +1,4 @@
-# Lossless capture & IR specification (v1)
+# Lossless capture & IR specification (v1.1)
 
 This spec defines how Nkokan captures third-party sources in a **lossless enough** way to support:
 
@@ -10,7 +10,7 @@ It is **stack-neutral**: it defines data contracts and invariants, not implement
 
 ## Goals
 
-- **Immutable raw snapshots**: the captured “evidence” is stable over time.
+- **Immutable raw snapshots**: the captured "evidence" is stable over time.
 - **Reproducible extraction**: parsers can reference the exact fragment used.
 - **Traceability**: every extracted piece can point back to a snapshot + fragment pointer.
 - **Change tolerance**: parsing/normalization rules can change without requiring re-download.
@@ -18,7 +18,7 @@ It is **stack-neutral**: it defines data contracts and invariants, not implement
 ## Non-goals
 
 - Choosing a crawler or storage backend.
-- Defining full dictionary schemas (entries/senses/etc.) beyond what’s needed for capture/IR links.
+- Defining full dictionary schemas (entries/senses/etc.) beyond what's needed for capture/IR links.
 
 ## Terminology
 
@@ -91,9 +91,9 @@ If you store HTTP request/response headers or similar metadata, you MUST:
 
 - apply a **redaction policy** before persistence (cookies, auth headers, tokens, session identifiers, user identifiers)
 - record which policy was applied via `redaction_policy_id` (or equivalent) on the snapshot metadata when headers are stored
-- store only what’s needed for reproducibility/debugging
+- store only what's needed for reproducibility/debugging
 
-Rationale: snapshots are “evidence,” but we must not accidentally persist secrets.
+Rationale: snapshots are "evidence," but we must not accidentally persist secrets.
 
 ## Fragment pointers (referencing evidence inside a snapshot)
 
@@ -109,7 +109,7 @@ A fragment pointer MUST include:
   - `css_selector`
   - `xpath`
   - `byte_span` (start/end offsets in raw bytes) when feasible
-  - `text_quote` (exact snippet or “quote” for anchoring)
+  - `text_quote` (exact snippet or "quote" for anchoring)
 - **`fragment_hash`**: strongly recommended; required in Phase 2 when feasible (see below)
 
 #### `fragment_hash` definition (must be unambiguous)
@@ -143,6 +143,8 @@ Notes:
 - Locators are allowed to be imperfect (sites change), but `snapshot_id` + `fragment_hash` MUST still anchor what was used.
 - For HTML, prefer a structural locator (`css_selector`/`xpath`) + a `text_quote` anchor.
 
+---
+
 ## Phase 1.2: Lossless IR
 
 IR sits between raw capture and normalized lexicon records.
@@ -153,26 +155,72 @@ IR sits between raw capture and normalized lexicon records.
 - Keep enough structure that normalization can be deterministic and versioned later.
 - Keep provenance hooks: every IR unit points back to snapshot(s) and fragment(s).
 
-### IR unit shape (conceptual)
+### IR kinds (document type discrimination)
 
-An IR unit SHOULD represent “one source record” (e.g., one dictionary entry on a page) and include:
+Different source document types produce different IR shapes. To prevent schema confusion and enable type-specific validation:
 
-- **`ir_id`**: stable internal identifier
+**`ir_kind`** (required): discriminator for the IR unit type.
+
+Supported values:
+
+| `ir_kind` | Description | Example |
+|-----------|-------------|---------|
+| `lexicon_entry` | Dictionary entry from a lexicon page (headword + senses + examples) | Mali-pense `/emk/lexicon/a.htm` |
+| `index_mapping` | Mapping from one language to entry references | Mali-pense `/emk/index-french/a.htm` |
+| `metadata_page` | Landing/info pages with metadata but not lexical entries | Mali-pense `/emk/lexicon/indexfr.htm` |
+
+Different `ir_kind` values have different `fields_raw` schemas. Parsers SHOULD validate against the appropriate schema.
+
+### IR unit shape (required fields)
+
+An IR unit MUST include:
+
+- **`ir_id`**: stable internal identifier (see computation rules below)
+- **`ir_kind`**: document type discriminator (see above)
 - **`source_id`**: stable join key from the Source Registry
-- **`source_name`**: optional display label
-- **`retrieved_at`**: when its evidence snapshot was retrieved
-- **`evidence`**: one or more fragment pointers (see above)
-- **`record_locator`**: required identity hint for the source record within a snapshot (see below)
-- **`fields_raw`**: extracted candidate fields *as found*, e.g.:
-  - headword/lemma candidates
-  - POS labels (`pos_raw`) as strings
-  - gloss/translation strings
-  - examples (original + translations if present)
-  - notes/usage labels
+- **`evidence`**: one or more fragment pointers covering the **full entry block** (see evidence rules below)
+- **`record_locator`**: required identity hint for the source record (see below)
+- **`fields_raw`**: extracted candidate fields *as found* (see field extraction rules below)
 - **`parse_warnings[]`**: non-fatal warnings when structure is unclear
-- **`parser_version`**: version stamp of the parser used to produce this IR (not the normalization version)
+- **`parser_version`**: version stamp of the parser used to produce this IR
 
-### `record_locator` (required; prevents duplicates on multi-entry pages)
+**Fields NOT stored on IR units (join instead):**
+
+- ~~`retrieved_at`~~: Belongs to the snapshot. Join via `evidence[].snapshot_id` → `snapshot.retrieved_at`.
+- ~~`source_name`~~: Belongs to Source Registry. Join via `source_id`.
+
+Rationale: Avoid denormalized data that can drift. Timestamps and display names are authoritative on their origin records.
+
+### `ir_id` computation (normative, collision-safe)
+
+`ir_id` MUST be deterministic and globally unique.
+
+**Problem:** Source-internal IDs (e.g., `id="e15"`) are often **page-scoped** and will collide across pages. Mali-pense has `e15` on every lexicon page.
+
+**Required computation:**
+
+```
+ir_id = sha256(source_id + "|" + url_canonical + "|" + record_id_component + "|" + parser_version)[:16]
+```
+
+Where:
+- `source_id`: from Source Registry (e.g., `src_malipense`)
+- `url_canonical`: the page URL (required for global uniqueness)
+- `record_id_component`: the page-scoped ID (e.g., `e15`) OR stringified `entry_index` if no ID exists
+- `parser_version`: ensures different parser versions produce different IDs
+
+**Example:**
+```python
+ir_id = sha256("src_malipense|https://www.mali-pense.net/emk/lexicon/a.htm|e15|malipense_lexicon_v1")[:16]
+# Result: "a7b3c9d2e1f04567"
+```
+
+This produces a collision-safe identifier that is:
+- **Deterministic**: same inputs → same ID
+- **Globally unique**: includes URL
+- **Versioned**: parser changes produce new IDs
+
+### `record_locator` (required; prevents duplicates)
 
 IR MUST include a `record_locator` describing how this IR unit corresponds to a specific record within the captured evidence.
 
@@ -185,26 +233,164 @@ To prevent drift across implementations, `record_locator.kind` MUST be one of:
 - `css_selector+text_quote`
 - `page+bbox+block_index`
 
-Preferred (in order):
+#### `record_locator` required fields by kind
 
-- `source_record_id` (if the source publishes stable IDs)
-- else `url_canonical` + `entry_index` (index within the page/record list as parsed)
-- else `css_selector` + `text_quote` (the same anchors used in evidence extraction)
+**`kind: "source_record_id"` (preferred when source has stable IDs):**
 
-The goal is not perfection; it is to ensure you can reconcile duplicates and understand how IR units relate to page structure.
+```json
+{
+  "kind": "source_record_id",
+  "url_canonical": "https://...",           // REQUIRED for global uniqueness
+  "source_record_id": "e15",                // Page-scoped ID from source
+  "anchor_names": ["ábadàn", "abadan"]      // Optional: human-friendly anchors
+}
+```
 
-#### `entry_index` semantics (required if used)
+**Important:** `url_canonical` is REQUIRED even for `source_record_id` kind because source IDs are typically page-scoped.
+
+**`kind: "url_canonical+entry_index"` (when no stable ID exists):**
+
+```json
+{
+  "kind": "url_canonical+entry_index",
+  "url_canonical": "https://...",
+  "entry_index": 0                          // 0-based, DOM order
+}
+```
+
+#### `entry_index` semantics (if used)
 
 If you use `entry_index` in a `record_locator`, it MUST be:
 
 - **0-based**
 - computed in **DOM order** for HTML snapshots
-- computed after applying the parser’s deterministic “entry selection” rule for that source (e.g., selector + filtering)
-- stable **within a snapshot for a given parser version**; it is allowed to change across parser versions (which is why `record_locator` should be paired with evidence anchors like selectors/quotes when possible)
+- computed after applying the parser's deterministic "entry selection" rule for that source
+- stable **within a snapshot for a given parser version**
 
-IR MUST be “rerunnable”:
+### Evidence pointers (must cover full entry block)
 
-- Re-parsing the same snapshots with a new parser version produces a new IR set (new `parser_version`) without mutating old IR.
+Evidence MUST reference the **complete entry block**, not just the headword element.
+
+**Problem:** An entry like `#e15` is a `<span>` containing just the headword. The full entry includes multiple sibling paragraphs with senses, examples, etc. Evidence pointing only to `#e15` loses auditability for downstream data.
+
+**Required:** Store evidence covering the entry block boundary:
+
+```json
+{
+  "evidence": [{
+    "source_id": "src_malipense",
+    "snapshot_id": "abc123...",
+    "entry_block": {
+      "start_selector": "span#e15",
+      "end_selector": "span#e16",            // Next entry (exclusive)
+      "block_selectors": [                   // OR explicit list
+        "p.lxP:has(#e15)",
+        "p.lxP2:nth-of-type(1)",
+        "p.lxP2:nth-of-type(2)"
+      ]
+    },
+    "text_quote": "ábadàn",                  // Anchor text for verification
+    "fragment_hash": "sha256:..."            // Hash of the block content
+  }]
+}
+```
+
+The parser MUST define its entry block boundary rule (e.g., "from `p.lxP` containing `#eN` until next `p.lxP`").
+
+### `fields_raw` extraction rules (conservative)
+
+IR is for **preservation**, not interpretation. Extract fields literally.
+
+#### Rule: Don't over-interpret compound strings
+
+**Example problem:** Mali-pense `<span class="PS">adv jamais</span>` contains POS + gloss concatenated.
+
+**Wrong (over-interpretation):**
+```json
+{
+  "pos_raw": "adv",
+  "gloss_fr": "jamais"
+}
+```
+
+**Correct (literal extraction):**
+```json
+{
+  "ps_raw": "adv jamais",           // Exactly as found in span.PS
+  "pos_hint": "adv"                 // Optional, only if parser is confident
+}
+```
+
+Glosses should come from dedicated gloss elements (`GlFr`, `GlEn`, etc.), not from the PS line.
+
+#### Rule: Distinguish "provided" vs "generated" forms
+
+If the source provides data that might also be generated later (e.g., N'Ko script), mark it explicitly:
+
+```json
+{
+  "headword_latin": "ábadàn",
+  "headword_nko_provided": "ߤߓߊߘߊ߲߫",   // From source (preserve as-is)
+  // Later phases may add:
+  // "headword_nko_generated": "..."      // From transliteration
+}
+```
+
+This prevents confusion about whether N'Ko forms came from the source or were generated.
+
+### `fields_raw` schemas by `ir_kind`
+
+#### `ir_kind: "lexicon_entry"`
+
+```json
+{
+  "fields_raw": {
+    "headword_latin": "ábadàn",
+    "headword_nko_provided": "ߤߓߊߘߊ߲߫",
+    "anchor_names": ["ábadàn", "abadan"],
+    "ps_raw": "adv jamais",
+    "pos_hint": "adv",
+    "senses": [
+      {
+        "sense_num": 1,
+        "gloss_fr": "jamais",
+        "gloss_en": "never",
+        "gloss_ru": "никогда́",
+        "examples": [
+          {
+            "text_latin": "wùlu` ní ɲàari` té díya hábadan",
+            "text_nko_provided": "ߥߎ߬ߟߎ ߣߌ߫...",
+            "trans_fr": "le chien et le chat...",
+            "trans_en": "a dog and a cat...",
+            "source_attribution": "[Diane Mamadi]"
+          }
+        ]
+      }
+    ],
+    "variants_raw": ["hábadan", "hábada"],
+    "synonyms_raw": ["bedebeli", "kádawù"],
+    "etymology_raw": "Ar. ...",
+    "literal_meaning_raw": "( ... )"
+  }
+}
+```
+
+#### `ir_kind: "index_mapping"`
+
+```json
+{
+  "fields_raw": {
+    "source_term": "abandonner",
+    "source_lang": "fr",
+    "target_entries": [
+      {"lexicon_url": "../lexicon/b.htm", "anchor": "e504", "display_text": "bàn"},
+      {"lexicon_url": "../lexicon/b.htm", "anchor": "e1096", "display_text": "bìla"}
+    ]
+  }
+}
+```
+
+---
 
 ## Linking IR to provenance (entry/sense/example)
 
@@ -215,9 +401,8 @@ At minimum, normalized records should be able to set:
 - `provenance.source.record_pointer.kind = "snapshot"`
 - `snapshot_id` from the IR evidence
 - selector/span/quote information (best-effort)
-- `retrieved_at` copied through
 
-This ensures we can always explain “where did this come from?”
+Join to snapshot for `retrieved_at` (do not copy to avoid drift).
 
 ## Versioning (parser vs normalization)
 
@@ -226,7 +411,11 @@ This spec only requires versioning fields that prevent silent mutation and suppo
 - **`parser_version`** (mandatory on IR): identifies the extractor that produced IR from snapshot+fragments.
 - **Normalization / mapping versions** (mandatory downstream): normalized/display records MUST record the versions of transformation rules applied (e.g., normalization, transliteration, POS mapping). See `shared/specs/provenance.md` (`derivation.rule_versions`).
 
-Do not overload `parser_version` to mean “normalization version”: they change for different reasons and must be recorded independently.
+Do not overload `parser_version` to mean "normalization version": they change for different reasons and must be recorded independently.
+
+IR MUST be "rerunnable":
+
+- Re-parsing the same snapshots with a new parser version produces a new IR set (new `parser_version`) without mutating old IR.
 
 ## Removal/disablement requirements
 
@@ -247,7 +436,7 @@ This spec stops at capture + IR, but it MUST be explicit about mutability bounda
 - IR is immutable once written (new parser versions produce new IR; old IR is preserved).
 - Human/editorial changes MUST be stored as **separate override/correction records** that reference a target record + scope; they MUST NOT mutate snapshot, fragment, IR, or normalized base records in place.
 
-This prevents “just edit the DB row” drift and preserves auditability/rollback.
+This prevents "just edit the DB row" drift and preserves auditability/rollback.
 
 ### Minimal correction record schema (required)
 
@@ -265,12 +454,14 @@ It MAY include `reason_code` and optional evidence pointers (bbox/screenshot/aud
 
 #### `patch_payload` format (pinned)
 
-To avoid “two valid interpretations,” `patch_payload` MUST be an **RFC 6902 JSON Patch** payload:
+To avoid "two valid interpretations," `patch_payload` MUST be an **RFC 6902 JSON Patch** payload:
 
 - `patch_payload` is an array of operations (`add`, `remove`, `replace`, etc.)
 - each operation MUST include `op` + `path`, and `value` when required by RFC 6902
 
 If a correction targets a record scope (`entry`/`sense`/`example`/`form`), the JSON Patch `path` MUST be interpreted relative to the JSON object representing that scope.
+
+---
 
 ## Extension: books (PDFs + scans) as sources (Phase 1 compatible)
 
@@ -303,7 +494,7 @@ To avoid ambiguity in highlighting and fragment comparison, `bbox` MUST follow t
 - **Origin**: top-left of the page/image
 - **Units**: normalized floats in the range \([0, 1]\), relative to the full page/image width/height
 - **Reference space**: full page/image (not a cropped subregion). If a crop is applied, record the crop explicitly alongside the locator (implementation-defined).
-- **Rotation**: locators SHOULD be expressed in a normalized “upright” orientation. If the underlying page/image is rotated, record `rotation_degrees` (one of `0`, `90`, `180`, `270`) and compute `bbox` in the upright coordinate space.
+- **Rotation**: locators SHOULD be expressed in a normalized "upright" orientation. If the underlying page/image is rotated, record `rotation_degrees` (one of `0`, `90`, `180`, `270`) and compute `bbox` in the upright coordinate space.
 
 ### OCR stance (important)
 
@@ -321,78 +512,125 @@ If OCR is performed, the OCR output MUST be represented as IR units that:
 - include `ocr_engine` and `ocr_version`
 - reference the underlying evidence fragment (snapshot + page + bbox) in `evidence[]`
 
+---
+
 ## Normative examples
 
-These are intentionally concrete; they are here to prevent “two correct interpretations.”
+These are intentionally concrete; they are here to prevent "two correct interpretations."
 
-### Example A: HTML page with 3 entries → 3 IR units
+### Example A: HTML lexicon page with entries → IR units
 
 Snapshot metadata:
 
 ```json
 {
-  "snapshot_id": "snap_123",
+  "snapshot_id": "a7b3c9d2e1f04567",
   "source_id": "src_malipense",
-  "source_name": "Mali-pense French → Maninka dictionary",
   "snapshot_kind": "html",
-  "url": "https://example.invalid/page/42",
-  "snapshot_group_id": "crawl_2026-01-04_malipense_v1",
-  "url_canonical": "https://example.invalid/page/42",
+  "url_canonical": "https://www.mali-pense.net/emk/lexicon/a.htm",
   "url_canonicalization_version": "urlcanon_v1",
-  "source_record_id": null,
-  "retrieved_at": "2026-01-04T12:34:56Z",
+  "retrieved_at": "2026-01-22T04:27:47Z",
   "http_status": 200,
   "content_type": "text/html; charset=utf-8",
-  "content_hash": "sha256:...",
-  "byte_length": 54321,
-  "encoding": "utf-8"
+  "content_sha256": "487846e7fb73de88...",
+  "byte_length": 217276
 }
 ```
 
-IR unit #0 (first entry on the page):
+IR unit for entry `e15` (ábadàn):
 
 ```json
 {
-  "ir_id": "ir_abc_0",
+  "ir_id": "f8a2b1c3d4e56789",
+  "ir_kind": "lexicon_entry",
   "source_id": "src_malipense",
-  "source_name": "Mali-pense French → Maninka dictionary",
-  "retrieved_at": "2026-01-04T12:34:56Z",
-  "parser_version": "parser_v1",
-  "evidence": [
-    {
-      "source_id": "src_malipense",
-      "snapshot_id": "snap_123",
-      "css_selector": "div.entry:nth-child(1)",
-      "text_quote": "…",
-      "fragment_representation_kind": "text_quote_utf8",
-      "fragment_hash": "sha256:..."
-    }
-  ],
+  "parser_version": "malipense_lexicon_v1",
+  "evidence": [{
+    "source_id": "src_malipense",
+    "snapshot_id": "a7b3c9d2e1f04567",
+    "entry_block": {
+      "start_selector": "span#e15",
+      "end_selector": "span#e16"
+    },
+    "text_quote": "ábadàn"
+  }],
   "record_locator": {
-    "kind": "url_canonical+entry_index",
-    "url_canonical": "https://example.invalid/page/42",
-    "entry_index": 0
+    "kind": "source_record_id",
+    "url_canonical": "https://www.mali-pense.net/emk/lexicon/a.htm",
+    "source_record_id": "e15",
+    "anchor_names": ["ábadàn", "abadan"]
   },
   "fields_raw": {
-    "headword_candidates": ["bara", "bàra"],
-    "pos_raw": ["n."],
-    "translations_raw": ["travail", "ouvrage"],
-    "examples_raw": [
+    "headword_latin": "ábadàn",
+    "headword_nko_provided": "ߤߓߊߘߊ߲߫",
+    "anchor_names": ["ábadàn", "abadan"],
+    "ps_raw": "adv jamais",
+    "pos_hint": "adv",
+    "senses": [
       {
-        "source_text": "A bàra kɛ.",
-        "translation_text": "Il travaille."
+        "sense_num": 1,
+        "gloss_fr": "jamais",
+        "gloss_en": "never",
+        "gloss_ru": "никогда́",
+        "examples": [
+          {
+            "text_latin": "wùlu` ní ɲàari` té díya hábadan",
+            "text_nko_provided": "ߥߎ߬ߟߎ ߣߌ߫ ߢߊ߰ߙߌ ߕߋ߫ ߘߌߦߊ߫ ߤߓߊߘߊ߲߫",
+            "trans_fr": "le chien et le chat ne seront jamais en bonnes relations",
+            "trans_en": "a dog and a cat will never live in peace",
+            "source_attribution": "[Diane Mamadi]"
+          }
+        ]
+      },
+      {
+        "sense_num": 2,
+        "gloss_fr": "toujours, pour toujours",
+        "gloss_en": "always, for ever",
+        "gloss_ru": "всегда́, навсегда́"
       }
+    ],
+    "variants_raw": ["hábadan", "hábada", "háyibadan"]
+  },
+  "parse_warnings": []
+}
+```
+
+### Example B: French index mapping → IR unit
+
+```json
+{
+  "ir_id": "b2c3d4e5f6a78901",
+  "ir_kind": "index_mapping",
+  "source_id": "src_malipense",
+  "parser_version": "malipense_index_v1",
+  "evidence": [{
+    "source_id": "src_malipense",
+    "snapshot_id": "c9d8e7f6a5b43210",
+    "css_selector": "tr:has(span.IxFr:contains('abandonner'))",
+    "text_quote": "abandonner"
+  }],
+  "record_locator": {
+    "kind": "url_canonical+entry_index",
+    "url_canonical": "https://www.mali-pense.net/emk/index-french/a.htm",
+    "entry_index": 35
+  },
+  "fields_raw": {
+    "source_term": "abandonner",
+    "source_lang": "fr",
+    "target_entries": [
+      {"lexicon_url": "../lexicon/b.htm", "anchor": "e504", "display_text": "bàn"},
+      {"lexicon_url": "../lexicon/b.htm", "anchor": "e1096", "display_text": "bìla"},
+      {"lexicon_url": "../lexicon/b.htm", "anchor": "e1423", "display_text": "bólokà"},
+      {"lexicon_url": "../lexicon/k.htm", "anchor": "e5194", "display_text": "kɔ́n"},
+      {"lexicon_url": "../lexicon/l.htm", "anchor": "e5589", "display_text": "lábìla"},
+      {"lexicon_url": "../lexicon/l.htm", "anchor": "e5650", "display_text": "láfìli"}
     ]
   },
   "parse_warnings": []
 }
+```
 
-The same snapshot MUST produce:
-
-- an `entry_index: 1` IR unit for the second entry
-- an `entry_index: 2` IR unit for the third entry
-
-### Example B: PDF fragment + derived OCR IR
+### Example C: PDF fragment + derived OCR IR
 
 PDF snapshot metadata:
 
@@ -400,50 +638,32 @@ PDF snapshot metadata:
 {
   "snapshot_id": "snap_pdf_001",
   "source_id": "src_some_book",
-  "source_name": "Some Book (Maninka lexicon)",
   "snapshot_kind": "pdf",
   "url": "file:///imports/some_book.pdf",
   "retrieved_at": "2026-01-04T12:34:56Z",
   "content_type": "application/pdf",
-  "content_hash": "sha256:...",
+  "content_sha256": "...",
   "byte_length": 987654
 }
 ```
 
-PDF fragment pointer (page + bbox):
-
-```json
-{
-  "source_id": "src_some_book",
-  "snapshot_id": "snap_pdf_001",
-  "page_number": 12,
-  "rotation_degrees": 0,
-  "bbox": { "x": 0.10, "y": 0.25, "w": 0.80, "h": 0.10 },
-  "pdf_text_quote": "…",
-  "fragment_representation_kind": "locator_jcs_v1",
-  "fragment_hash": "sha256:..."
-}
-```
-
-Derived OCR IR unit (separate IR; references the same evidence):
+Derived OCR IR unit:
 
 ```json
 {
   "ir_id": "ir_ocr_12_0",
+  "ir_kind": "lexicon_entry",
   "source_id": "src_some_book",
-  "snapshot_id": "snap_pdf_001",
   "parser_version": "ocr_pipeline_v1",
   "ocr_engine": "tesseract",
   "ocr_version": "5.x",
-  "evidence": [
-    {
-      "source_id": "src_some_book",
-      "snapshot_id": "snap_pdf_001",
-      "page_number": 12,
-      "rotation_degrees": 0,
-      "bbox": { "x": 0.10, "y": 0.25, "w": 0.80, "h": 0.10 }
-    }
-  ],
+  "evidence": [{
+    "source_id": "src_some_book",
+    "snapshot_id": "snap_pdf_001",
+    "page_number": 12,
+    "rotation_degrees": 0,
+    "bbox": { "x": 0.10, "y": 0.25, "w": 0.80, "h": 0.10 }
+  }],
   "record_locator": {
     "kind": "page+bbox+block_index",
     "page_number": 12,
@@ -451,10 +671,25 @@ Derived OCR IR unit (separate IR; references the same evidence):
     "block_index": 0
   },
   "fields_raw": {
-    "ocr_text": "…"
+    "ocr_text": "..."
   },
   "parse_warnings": []
 }
 ```
-```
 
+---
+
+## Changelog
+
+### v1.1 (2026-01-26)
+
+- Added `ir_kind` discriminator for document type (lexicon_entry, index_mapping, metadata_page)
+- Made `ir_id` computation normative and collision-safe (requires url_canonical)
+- Removed `retrieved_at` and `source_name` from IR units (join instead)
+- Required `url_canonical` on all `record_locator` kinds for global uniqueness
+- Added `anchor_names` field to `record_locator` for human-friendly lookups
+- Required evidence pointers to cover full entry block, not just headword
+- Added `fields_raw` extraction rules (conservative, literal extraction)
+- Distinguished "provided" vs "generated" forms (e.g., `headword_nko_provided`)
+- Added `fields_raw` schemas by `ir_kind`
+- Updated normative examples for Mali-pense structure


### PR DESCRIPTION
Updated lossless-capture-and-ir.md spec to v1.1 with:
- ir_kind discriminator (lexicon_entry, index_mapping, metadata_page)
- Deterministic ir_id computation (collision-safe across pages)
- Evidence pointers covering full entry block (not just headword)
- Conservative fields_raw extraction (ps_raw verbatim, pos_hint optional)
- Distinguished "provided" vs "generated" forms (headword_nko_provided)
- Removed retrieved_at/source_name from IR (join via snapshot)

Added shared/ir/models.py with:
- IRUnit, RecordLocator, EvidencePointer dataclasses
- compute_ir_id() deterministic hash function
- LexiconEntryFieldsRaw, IndexMappingFieldsRaw schemas

Added api/ir_parser/ with:
- MalipenseLexiconParser for /emk/lexicon/{letter}.htm pages
- CLI to process all lexicon snapshots

Tested: 8,823 entries parsed from 26 lexicon pages, 0 errors.

## What does this PR change?

- 

## Why?

- 

## Checklist (required)

- [ ] I kept this PR narrowly scoped.
- [ ] If I changed language data / meaning, I explained the impact and any uncertainty.
- [ ] If this touches third-party sources, I preserved attribution and did not add content without permission.
- [ ] If this changes normalization/transliteration behavior, I added examples (inputs → outputs) in the PR description.

## Screenshots / notes (if applicable)

- 

