### PR TITLE
feat(web): add Phase 4 catalog-driven bundle installs

### DIFF
--- a/web/src/bundle_catalog.test.ts
+++ b/web/src/bundle_catalog.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compareCatalogEntryToInstalled,
+  deriveBundleAssetUrls,
+  fetchBundleCatalog,
+  parseAndValidateBundleCatalogJson,
+  resolveBundleBaseUrl,
+  resolveCatalogUrl,
+  validateRemoteUrlPolicy,
+} from "./bundle_catalog";
+
+describe("Phase 4.1 bundle catalog parsing", () => {
+  it("parses a valid catalog with two bundles", () => {
+    const result = parseAndValidateBundleCatalogJson(
+      JSON.stringify({
+        catalog_schema_version: "bundle_catalog_v1",
+        bundles: [
+          {
+            bundle_id: "maninka_fr_v1",
+            name: "French ↔ Maninka",
+            version: "1.0.0",
+            size_bytes: 20971520,
+            url_base: "/bundles/maninka_fr_v1/",
+            content_sha256: "sha256:aaa",
+            languages: { source_lang: "fr", target_lang: "mnk" },
+            language_labels: { source: "French", target: "Maninka" },
+          },
+          {
+            bundle_id: "fula_fr_v1",
+            name: "French ↔ Fula",
+            version: "1.0.0",
+            size_bytes: 25165824,
+            url_base: "/bundles/fula_fr_v1/",
+            content_sha256: "sha256:bbb",
+          },
+        ],
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.catalog?.bundles).toHaveLength(2);
+    expect(result.catalog?.bundles.map((bundle) => bundle.bundle_id)).toEqual(["fula_fr_v1", "maninka_fr_v1"]);
+    expect(result.catalog?.bundles[1]).toMatchObject({
+      bundle_id: "maninka_fr_v1",
+      name: "French ↔ Maninka",
+      version: "1.0.0",
+      size_bytes: 20971520,
+      url_base: "/bundles/maninka_fr_v1/",
+      content_sha256: "sha256:aaa",
+      language_meta: {
+        source_lang: "fr",
+        target_lang: "mnk",
+        source_label: "French",
+        target_label: "Maninka",
+      },
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("rejects duplicate bundle ids and invalid sizes", () => {
+    const result = parseAndValidateBundleCatalogJson(
+      JSON.stringify({
+        catalog_schema_version: "bundle_catalog_v1",
+        bundles: [
+          {
+            bundle_id: "bundle_a",
+            name: "Bundle A",
+            size_bytes: 10.5,
+            url_base: "/bundles/a/",
+            content_sha256: "sha256:aaa",
+          },
+          {
+            bundle_id: "bundle_a",
+            name: "Bundle A copy",
+            size_bytes: 20,
+            url_base: "/bundles/a-copy/",
+            content_sha256: "sha256:bbb",
+          },
+        ],
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("bundles[0].size_bytes must be a non-negative integer");
+    expect(result.errors).toContain("Duplicate bundle_id in catalog: bundle_a");
+  });
+
+  it("rejects missing content_sha256 and non-directory url_base", () => {
+    const result = parseAndValidateBundleCatalogJson(
+      JSON.stringify({
+        catalog_schema_version: "bundle_catalog_v1",
+        bundles: [
+          {
+            bundle_id: "bundle_a",
+            name: "Bundle A",
+            size_bytes: 20,
+            url_base: "/bundles/a",
+          },
+        ],
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("bundles[0].content_sha256 must be a non-empty string");
+    expect(result.errors).toContain(
+      "bundles[0].url_base must be a directory prefix ending with '/' and must not contain '?' or '#'",
+    );
+  });
+});
+
+describe("Phase 4.1 bundle catalog fetch", () => {
+  it("fetches, validates, and resolves relative bundle URLs", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({
+          catalog_schema_version: "bundle_catalog_v1",
+          bundles: [
+            {
+              bundle_id: "maninka_fr_v1",
+              name: "French ↔ Maninka",
+              size_bytes: 20971520,
+              url_base: "../bundles/maninka_fr_v1/",
+              content_sha256: "sha256:aaa",
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+
+    const result = await fetchBundleCatalog("./catalogs/guinea.json", {
+      baseUrl: "https://example.test/app/",
+      fetchImpl,
+    });
+
+    expect(result.requestUrl).toBe("https://example.test/app/catalogs/guinea.json");
+    expect(resolveCatalogUrl("./catalogs/guinea.json", "https://example.test/app/")).toBe(result.requestUrl);
+    expect(resolveBundleBaseUrl(result.responseUrl, result.catalog.bundles[0]!.url_base)).toBe(
+      "https://example.test/app/bundles/maninka_fr_v1/",
+    );
+    expect(deriveBundleAssetUrls(result.responseUrl, result.catalog.bundles[0]!)).toEqual({
+      base_url: "https://example.test/app/bundles/maninka_fr_v1/",
+      manifest_url: "https://example.test/app/bundles/maninka_fr_v1/bundle.manifest.json",
+      records_url: "https://example.test/app/bundles/maninka_fr_v1/records.jsonl",
+      search_index_url: "https://example.test/app/bundles/maninka_fr_v1/search_index.jsonl",
+    });
+  });
+
+  it("throws on non-200 catalog responses", async () => {
+    const fetchImpl: typeof fetch = async () => new Response("nope", { status: 404, statusText: "Not Found" });
+
+    await expect(
+      fetchBundleCatalog("https://example.test/catalog.json", {
+        fetchImpl,
+      }),
+    ).rejects.toThrow("Catalog request failed: 404 Not Found");
+  });
+
+  it("rejects unsafe remote schemes and non-local http hosts", () => {
+    expect(() => validateRemoteUrlPolicy("javascript:alert(1)")).toThrow(
+      "Remote URL must use https: or approved local http:",
+    );
+    expect(() => validateRemoteUrlPolicy("file:///tmp/catalog.json")).toThrow(
+      "Remote URL must use https: or approved local http:",
+    );
+    expect(() => validateRemoteUrlPolicy("http://example.com/catalog.json")).toThrow(
+      "Remote http: URLs are only allowed for same-origin or local hosts",
+    );
+    expect(() => validateRemoteUrlPolicy("http://192.168.1.10/catalog.json")).not.toThrow();
+    expect(() => validateRemoteUrlPolicy("http://siralex.local/catalog.json")).not.toThrow();
+  });
+
+  it("enforces catalog fetch size limits", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("x".repeat(32), {
+        status: 200,
+        headers: { "content-length": "32" },
+      });
+
+    await expect(
+      fetchBundleCatalog("https://example.test/catalog.json", {
+        fetchImpl,
+        maxBytes: 16,
+      }),
+    ).rejects.toThrow("Catalog response too large: 32 bytes exceeds 16 bytes");
+  });
+
+  it("supports abort signals", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("User cancelled"));
+
+    await expect(
+      fetchBundleCatalog("https://example.test/catalog.json", {
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("User cancelled");
+  });
+
+  it("times out stalled catalog requests", async () => {
+    const fetchImpl: typeof fetch = async (_input, init) =>
+      await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => {
+            reject(init.signal?.reason ?? new Error("aborted"));
+          },
+          { once: true },
+        );
+      });
+
+    await expect(
+      fetchBundleCatalog("https://example.test/catalog.json", {
+        fetchImpl,
+        timeoutMs: 5,
+      }),
+    ).rejects.toThrow("Catalog request timed out after 5 ms");
+  });
+});
+
+describe("Phase 4.1 update semantics", () => {
+  it("treats content_sha256 as authoritative update identity", () => {
+    const entry = {
+      bundle_id: "maninka_fr_v1",
+      name: "French ↔ Maninka",
+      version: "1.0.1",
+      size_bytes: 20,
+      url_base: "/bundles/maninka_fr_v1/",
+      content_sha256: "sha256:new",
+    };
+
+    expect(compareCatalogEntryToInstalled(entry)).toMatchObject({
+      state: "not_installed",
+      installed: false,
+      contentMatches: false,
+    });
+
+    expect(
+      compareCatalogEntryToInstalled(entry, {
+        bundle_id: "maninka_fr_v1",
+        expected_content_sha256: "sha256:new",
+      }),
+    ).toMatchObject({
+      state: "installed_current",
+      installed: true,
+      contentMatches: true,
+    });
+
+    expect(
+      compareCatalogEntryToInstalled(entry, {
+        bundle_id: "maninka_fr_v1",
+        expected_content_sha256: "sha256:old",
+      }),
+    ).toMatchObject({
+      state: "update_available",
+      installed: true,
+      contentMatches: false,
+    });
+  });
+});

--- a/web/src/bundle_catalog.ts
+++ b/web/src/bundle_catalog.ts
@@ -1,0 +1,398 @@
+import type { ActiveBundleMeta } from "./idb/siralex_db";
+
+export type BundleCatalogLanguageMeta = {
+  source_lang?: string;
+  target_lang?: string;
+  source_label?: string;
+  target_label?: string;
+};
+
+export type BundleCatalogEntryV1 = {
+  bundle_id: string;
+  name: string;
+  version?: string;
+  size_bytes: number;
+  url_base: string;
+  content_sha256: string;
+  language_meta?: BundleCatalogLanguageMeta;
+};
+
+export type BundleCatalogV1 = {
+  catalog_schema_version: string;
+  bundles: BundleCatalogEntryV1[];
+};
+
+export type BundleCatalogValidation = {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  catalog?: BundleCatalogV1;
+};
+
+export type FetchBundleCatalogOptions = {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  maxBytes?: number;
+};
+
+export type FetchBundleCatalogResult = {
+  requestUrl: string;
+  responseUrl: string;
+  catalog: BundleCatalogV1;
+  warnings: string[];
+};
+
+export const EXPECTED_BUNDLE_CATALOG_SCHEMA_VERSION = "bundle_catalog_v1";
+export const DEFAULT_CATALOG_FETCH_TIMEOUT_MS = 10_000;
+export const DEFAULT_CATALOG_MAX_BYTES = 1_048_576;
+export const BUNDLE_MANIFEST_FILENAME = "bundle.manifest.json";
+export const BUNDLE_RECORDS_FILENAME = "records.jsonl";
+export const BUNDLE_SEARCH_INDEX_FILENAME = "search_index.jsonl";
+
+export type BundleRemoteAssetUrls = {
+  base_url: string;
+  manifest_url: string;
+  records_url: string;
+  search_index_url: string;
+};
+
+export type BundleCatalogUpdateState =
+  | "not_installed"
+  | "installed_current"
+  | "update_available";
+
+export type BundleCatalogComparison = {
+  state: BundleCatalogUpdateState;
+  installed: boolean;
+  contentMatches: boolean;
+};
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null;
+}
+
+function getString(obj: Record<string, unknown>, key: string): string | undefined {
+  const value = obj[key];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+function getOptionalStringObject(
+  raw: unknown,
+  allowedKeys: string[],
+): Record<string, string> | undefined {
+  if (!isObject(raw)) return undefined;
+  const out: Record<string, string> = {};
+  for (const key of allowedKeys) {
+    const value = getString(raw, key);
+    if (value) out[key] = value;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function fmtExpected(actual: string | undefined, expected: string): string {
+  return `expected '${expected}', got '${actual ?? "undefined"}'`;
+}
+
+function normalizeLanguageMeta(raw: Record<string, unknown>): BundleCatalogLanguageMeta | undefined {
+  const languages = getOptionalStringObject(raw["languages"], ["source_lang", "target_lang"]);
+  const labels = getOptionalStringObject(raw["language_labels"], ["source", "target"]);
+  const meta: BundleCatalogLanguageMeta = {
+    source_lang: languages?.source_lang,
+    target_lang: languages?.target_lang,
+    source_label: labels?.source,
+    target_label: labels?.target,
+  };
+  return Object.values(meta).some((value) => value !== undefined) ? meta : undefined;
+}
+
+function isSafeDirectoryPrefix(urlBase: string): boolean {
+  return urlBase.endsWith("/") && !urlBase.includes("?") && !urlBase.includes("#");
+}
+
+function isPrivateIpv4Host(hostname: string): boolean {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) return false;
+  const nums = parts.map((part) => Number(part));
+  if (nums.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+  const [a, b] = nums as [number, number, number, number];
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  return false;
+}
+
+function isAllowedHttpHost(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  return (
+    lower === "localhost" ||
+    lower === "::1" ||
+    lower.endsWith(".local") ||
+    isPrivateIpv4Host(lower)
+  );
+}
+
+export function parseAndValidateBundleCatalogJson(text: string): BundleCatalogValidation {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text) as unknown;
+  } catch (error) {
+    return {
+      ok: false,
+      errors: [`Catalog is not valid JSON: ${String(error)}`],
+      warnings,
+    };
+  }
+
+  if (!isObject(raw)) {
+    return { ok: false, errors: ["Catalog JSON must be an object"], warnings };
+  }
+
+  const catalog_schema_version = getString(raw, "catalog_schema_version");
+  if (!catalog_schema_version) {
+    errors.push("Missing/invalid field: catalog_schema_version");
+  } else if (catalog_schema_version !== EXPECTED_BUNDLE_CATALOG_SCHEMA_VERSION) {
+    errors.push(
+      `catalog_schema_version mismatch: ${fmtExpected(
+        catalog_schema_version,
+        EXPECTED_BUNDLE_CATALOG_SCHEMA_VERSION,
+      )}`,
+    );
+  }
+
+  const bundlesRaw = raw["bundles"];
+  if (!Array.isArray(bundlesRaw)) {
+    errors.push("Missing/invalid field: bundles (array)");
+  }
+
+  const bundles: BundleCatalogEntryV1[] = [];
+  const seenBundleIds = new Set<string>();
+  if (Array.isArray(bundlesRaw)) {
+    for (const [index, entry] of bundlesRaw.entries()) {
+      if (!isObject(entry)) {
+        errors.push(`bundles[${index}] must be an object`);
+        continue;
+      }
+
+      const bundle_id = getString(entry, "bundle_id");
+      const name = getString(entry, "name");
+      const version = getString(entry, "version");
+      const url_base = getString(entry, "url_base");
+      const content_sha256 = getString(entry, "content_sha256");
+      const size_bytes_raw = entry["size_bytes"];
+      const size_bytes =
+        typeof size_bytes_raw === "number" && Number.isInteger(size_bytes_raw) && size_bytes_raw >= 0
+          ? size_bytes_raw
+          : undefined;
+
+      if (!bundle_id) errors.push(`bundles[${index}].bundle_id must be a non-empty string`);
+      if (!name) errors.push(`bundles[${index}].name must be a non-empty string`);
+      if (!url_base) errors.push(`bundles[${index}].url_base must be a non-empty string`);
+      if (url_base && !isSafeDirectoryPrefix(url_base)) {
+        errors.push(
+          `bundles[${index}].url_base must be a directory prefix ending with '/' and must not contain '?' or '#'`,
+        );
+      }
+      if (!content_sha256) {
+        errors.push(`bundles[${index}].content_sha256 must be a non-empty string`);
+      }
+      if (size_bytes === undefined) {
+        errors.push(`bundles[${index}].size_bytes must be a non-negative integer`);
+      }
+      if (bundle_id && seenBundleIds.has(bundle_id)) {
+        errors.push(`Duplicate bundle_id in catalog: ${bundle_id}`);
+      }
+
+      if (bundle_id) {
+        seenBundleIds.add(bundle_id);
+      }
+
+      if (bundle_id && name && url_base && content_sha256 && size_bytes !== undefined) {
+        const language_meta = normalizeLanguageMeta(entry);
+        bundles.push({
+          bundle_id,
+          name,
+          version,
+          size_bytes,
+          url_base,
+          content_sha256,
+          language_meta,
+        });
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors, warnings };
+  }
+
+  return {
+    ok: true,
+    errors,
+    warnings,
+    catalog: {
+      catalog_schema_version: catalog_schema_version!,
+      bundles: bundles.sort((a, b) => {
+        const nameCmp = a.name.localeCompare(b.name);
+        if (nameCmp !== 0) return nameCmp;
+        return a.bundle_id.localeCompare(b.bundle_id);
+      }),
+    },
+  };
+}
+
+export function resolveCatalogUrl(catalogUrl: string, baseUrl: string): string {
+  return new URL(catalogUrl, baseUrl).toString();
+}
+
+export function validateRemoteUrlPolicy(urlString: string, currentBaseUrl?: string): void {
+  const url = new URL(urlString);
+  if (url.protocol === "https:") return;
+  if (url.protocol !== "http:") {
+    throw new Error(`Remote URL must use https: or approved local http:, got ${url.protocol}`);
+  }
+
+  const currentOrigin = currentBaseUrl ? new URL(currentBaseUrl).origin : undefined;
+  const isSameOriginHttp = currentOrigin === url.origin;
+  if (isSameOriginHttp || isAllowedHttpHost(url.hostname)) {
+    return;
+  }
+
+  throw new Error(
+    `Remote http: URLs are only allowed for same-origin or local hosts (localhost, .local, private IPs), got ${url.hostname}`,
+  );
+}
+
+export function resolveBundleBaseUrl(catalogUrl: string, urlBase: string): string {
+  const resolved = new URL(urlBase, catalogUrl).toString();
+  validateRemoteUrlPolicy(resolved, catalogUrl);
+  return resolved;
+}
+
+export function deriveBundleAssetUrls(catalogUrl: string, entry: BundleCatalogEntryV1): BundleRemoteAssetUrls {
+  const base_url = resolveBundleBaseUrl(catalogUrl, entry.url_base);
+  return {
+    base_url,
+    manifest_url: new URL(BUNDLE_MANIFEST_FILENAME, base_url).toString(),
+    records_url: new URL(BUNDLE_RECORDS_FILENAME, base_url).toString(),
+    search_index_url: new URL(BUNDLE_SEARCH_INDEX_FILENAME, base_url).toString(),
+  };
+}
+
+export function compareCatalogEntryToInstalled(
+  entry: BundleCatalogEntryV1,
+  installed?: Pick<ActiveBundleMeta, "bundle_id" | "expected_content_sha256">,
+): BundleCatalogComparison {
+  if (!installed || installed.bundle_id !== entry.bundle_id) {
+    return {
+      state: "not_installed",
+      installed: false,
+      contentMatches: false,
+    };
+  }
+
+  const contentMatches = installed.expected_content_sha256 === entry.content_sha256;
+  return {
+    state: contentMatches ? "installed_current" : "update_available",
+    installed: true,
+    contentMatches,
+  };
+}
+
+function createFetchSignal(timeoutMs: number, externalSignal?: AbortSignal): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort(new Error(`Catalog request timed out after ${timeoutMs} ms`));
+  }, timeoutMs);
+
+  const onAbort = () => {
+    controller.abort(externalSignal?.reason ?? new Error("Catalog request aborted"));
+  };
+
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      onAbort();
+    } else {
+      externalSignal.addEventListener("abort", onAbort, { once: true });
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      externalSignal?.removeEventListener("abort", onAbort);
+    },
+  };
+}
+
+function getTextByteLength(text: string): number {
+  return new TextEncoder().encode(text).byteLength;
+}
+
+export async function fetchBundleCatalog(
+  catalogUrl: string,
+  options: FetchBundleCatalogOptions = {},
+): Promise<FetchBundleCatalogResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CATALOG_FETCH_TIMEOUT_MS;
+  const maxBytes = options.maxBytes ?? DEFAULT_CATALOG_MAX_BYTES;
+  const requestUrl = options.baseUrl ? resolveCatalogUrl(catalogUrl, options.baseUrl) : catalogUrl;
+  validateRemoteUrlPolicy(requestUrl, options.baseUrl);
+  const { signal, cleanup } = createFetchSignal(timeoutMs, options.signal);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(requestUrl, {
+      headers: { Accept: "application/json" },
+      signal,
+    });
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
+  cleanup();
+
+  if (!response.ok) {
+    throw new Error(`Catalog request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const responseUrl = response.url || requestUrl;
+  validateRemoteUrlPolicy(responseUrl, options.baseUrl);
+
+  const contentLength = response.headers.get("content-length");
+  if (contentLength) {
+    const parsedLength = Number(contentLength);
+    if (Number.isFinite(parsedLength) && parsedLength > maxBytes) {
+      throw new Error(`Catalog response too large: ${parsedLength} bytes exceeds ${maxBytes} bytes`);
+    }
+  }
+
+  const text = await response.text();
+  const actualBytes = getTextByteLength(text);
+  if (actualBytes > maxBytes) {
+    throw new Error(`Catalog response too large: ${actualBytes} bytes exceeds ${maxBytes} bytes`);
+  }
+  const parsed = parseAndValidateBundleCatalogJson(text);
+  if (!parsed.ok || !parsed.catalog) {
+    throw new Error(`Catalog validation failed: ${parsed.errors.join("; ")}`);
+  }
+
+  return {
+    requestUrl,
+    responseUrl,
+    catalog: parsed.catalog,
+    warnings: parsed.warnings,
+  };
+}

--- a/web/src/idb/siralex_db.ts
+++ b/web/src/idb/siralex_db.ts
@@ -24,6 +24,7 @@ export type BundleLanguageMeta = {
 
 export type ActiveBundleMeta = {
   bundle_id: string;
+  storage_scope_id?: string;
   manifest_schema_version: string;
   record_schema_id: string;
   record_schema_version: string;
@@ -35,6 +36,38 @@ export type ActiveBundleMeta = {
   records_count?: number;
   index_entries_count?: number;
   language_meta?: BundleLanguageMeta;
+};
+
+export type CachedBundleCatalog = {
+  request_url: string;
+  response_url: string;
+  fetched_at_iso: string;
+  warnings: string[];
+  catalog: {
+    catalog_schema_version: string;
+    bundles: Array<{
+      bundle_id: string;
+      name: string;
+      version?: string;
+      size_bytes: number;
+      url_base: string;
+      content_sha256: string;
+      language_meta?: {
+        source_lang?: string;
+        target_lang?: string;
+        source_label?: string;
+        target_label?: string;
+      };
+    }>;
+  };
+};
+
+export type BundleInstallSession = {
+  bundle_id: string;
+  storage_scope_id: string;
+  started_at_iso: string;
+  phase: "staging" | "committed";
+  previous_storage_scope_id?: string;
 };
 
 function reqToPromise<T>(req: IDBRequest<T>): Promise<T> {
@@ -136,6 +169,8 @@ export async function metaDelete(db: IDBDatabase, key: string): Promise<void> {
 }
 
 export const META_ACTIVE_BUNDLE_ID_KEY = "active_bundle_id";
+export const META_CACHED_BUNDLE_CATALOG_KEY = "cached_bundle_catalog";
+export const META_BUNDLE_INSTALL_SESSION_KEY = "bundle_install_session";
 
 export async function getActiveBundleId(db: IDBDatabase): Promise<string | undefined> {
   return await metaGet<string>(db, META_ACTIVE_BUNDLE_ID_KEY);
@@ -159,6 +194,10 @@ export async function getInstalledBundleMeta(
   return value as ActiveBundleMeta | undefined;
 }
 
+export function getBundleStorageScopeId(meta: Pick<ActiveBundleMeta, "bundle_id" | "storage_scope_id">): string {
+  return meta.storage_scope_id ?? meta.bundle_id;
+}
+
 export async function listInstalledBundles(db: IDBDatabase): Promise<ActiveBundleMeta[]> {
   const tx = db.transaction(STORE_BUNDLES_REGISTRY, "readonly");
   const req = tx.objectStore(STORE_BUNDLES_REGISTRY).getAll();
@@ -176,6 +215,30 @@ export async function deleteInstalledBundleMeta(db: IDBDatabase, bundleId: strin
   const tx = db.transaction(STORE_BUNDLES_REGISTRY, "readwrite");
   tx.objectStore(STORE_BUNDLES_REGISTRY).delete(bundleId);
   await txDone(tx);
+}
+
+export async function getCachedBundleCatalog(db: IDBDatabase): Promise<CachedBundleCatalog | undefined> {
+  return await metaGet<CachedBundleCatalog>(db, META_CACHED_BUNDLE_CATALOG_KEY);
+}
+
+export async function setCachedBundleCatalog(db: IDBDatabase, cached: CachedBundleCatalog): Promise<void> {
+  await metaSet(db, META_CACHED_BUNDLE_CATALOG_KEY, cached);
+}
+
+export async function clearCachedBundleCatalog(db: IDBDatabase): Promise<void> {
+  await metaDelete(db, META_CACHED_BUNDLE_CATALOG_KEY);
+}
+
+export async function getBundleInstallSession(db: IDBDatabase): Promise<BundleInstallSession | undefined> {
+  return await metaGet<BundleInstallSession>(db, META_BUNDLE_INSTALL_SESSION_KEY);
+}
+
+export async function setBundleInstallSession(db: IDBDatabase, session: BundleInstallSession): Promise<void> {
+  await metaSet(db, META_BUNDLE_INSTALL_SESSION_KEY, session);
+}
+
+export async function clearBundleInstallSession(db: IDBDatabase): Promise<void> {
+  await metaDelete(db, META_BUNDLE_INSTALL_SESSION_KEY);
 }
 
 export async function getActiveBundleMeta(db: IDBDatabase): Promise<ActiveBundleMeta | undefined> {
@@ -206,9 +269,14 @@ async function deleteStoreRowsByBundleId(
   await txDone(tx);
 }
 
+export async function deleteBundleScopeData(db: IDBDatabase, storageScopeId: string): Promise<void> {
+  await deleteStoreRowsByBundleId(db, STORE_RECORDS, storageScopeId);
+  await deleteStoreRowsByBundleId(db, STORE_SEARCH_INDEX, storageScopeId);
+}
+
 export async function deleteBundleData(db: IDBDatabase, bundleId: string): Promise<void> {
-  await deleteStoreRowsByBundleId(db, STORE_RECORDS, bundleId);
-  await deleteStoreRowsByBundleId(db, STORE_SEARCH_INDEX, bundleId);
+  const installed = await getInstalledBundleMeta(db, bundleId);
+  await deleteBundleScopeData(db, installed ? getBundleStorageScopeId(installed) : bundleId);
   await deleteInstalledBundleMeta(db, bundleId);
   const activeBundleId = await getActiveBundleId(db);
   if (activeBundleId === bundleId) {
@@ -222,4 +290,21 @@ export async function setActiveBundleMeta(db: IDBDatabase, meta: ActiveBundleMet
   // are fully imported and the registry entry has been written successfully.
   await putInstalledBundleMeta(db, meta);
   await setActiveBundleId(db, meta.bundle_id);
+}
+
+export async function recoverInterruptedBundleInstall(db: IDBDatabase): Promise<string | undefined> {
+  const session = await getBundleInstallSession(db);
+  if (!session) return undefined;
+
+  if (session.phase === "staging") {
+    await deleteBundleScopeData(db, session.storage_scope_id);
+    await clearBundleInstallSession(db);
+    return `Recovered interrupted staged install for ${session.bundle_id}. Partial staged data was removed.`;
+  }
+
+  if (session.previous_storage_scope_id && session.previous_storage_scope_id !== session.storage_scope_id) {
+    await deleteBundleScopeData(db, session.previous_storage_scope_id);
+  }
+  await clearBundleInstallSession(db);
+  return `Recovered committed install for ${session.bundle_id}. Previous bundle data cleanup completed.`;
 }

--- a/web/src/import/import_records.ts
+++ b/web/src/import/import_records.ts
@@ -1,5 +1,5 @@
 import { STORE_RECORDS } from "../idb/siralex_db";
-import { streamJsonlLines, type JsonlStreamProgress } from "./jsonl_stream";
+import { streamJsonlLines, type JsonlByteSource, type JsonlStreamProgress } from "./jsonl_stream";
 
 export type ImportRecordsProgress = {
   bytesRead: number;
@@ -36,7 +36,7 @@ function txDone(tx: IDBTransaction): Promise<void> {
 
 export async function importRecordsJsonl(
   db: IDBDatabase,
-  recordsFile: File,
+  recordsFile: JsonlByteSource,
   options: ImportRecordsOptions,
 ): Promise<{ recordsWritten: number; linesSeen: number; batchesCommitted: number; duplicateKeysFound: string[] }> {
   const batchSize = options.batchSize ?? 500;
@@ -82,7 +82,9 @@ export async function importRecordsJsonl(
   }
 
   for await (const line of streamJsonlLines(recordsFile, { onProgress: handleStreamProgress, signal })) {
-    if (signal?.aborted) throw new Error("Aborted");
+    if (signal?.aborted) {
+      throw signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason ?? "Aborted"));
+    }
     linesSeen += 1;
 
     let obj: unknown;

--- a/web/src/import/import_search_index.ts
+++ b/web/src/import/import_search_index.ts
@@ -1,5 +1,5 @@
 import { STORE_SEARCH_INDEX } from "../idb/siralex_db";
-import { streamJsonlLines, type JsonlStreamProgress } from "./jsonl_stream";
+import { streamJsonlLines, type JsonlByteSource, type JsonlStreamProgress } from "./jsonl_stream";
 
 export type ImportSearchIndexProgress = {
   bytesRead: number;
@@ -43,7 +43,7 @@ export type SearchIndexEntry = {
 
 export async function importSearchIndexJsonl(
   db: IDBDatabase,
-  indexFile: File,
+  indexFile: JsonlByteSource,
   options: ImportSearchIndexOptions,
 ): Promise<{ entriesWritten: number; linesSeen: number; batchesCommitted: number; duplicateKeysFound: string[] }> {
   const batchSize = options.batchSize ?? 500;
@@ -86,7 +86,9 @@ export async function importSearchIndexJsonl(
   }
 
   for await (const line of streamJsonlLines(indexFile, { onProgress: handleStreamProgress, signal })) {
-    if (signal?.aborted) throw new Error("Aborted");
+    if (signal?.aborted) {
+      throw signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason ?? "Aborted"));
+    }
     linesSeen += 1;
 
     let obj: unknown;

--- a/web/src/import/jsonl_stream.ts
+++ b/web/src/import/jsonl_stream.ts
@@ -21,14 +21,16 @@ export type StreamJsonlOptions = {
   signal?: AbortSignal;
 };
 
+export type JsonlByteSource = Blob | ReadableStream<Uint8Array>;
+
 function throwIfAborted(signal: AbortSignal | undefined) {
   if (signal?.aborted) {
-    throw new Error("Aborted");
+    throw signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason ?? "Aborted"));
   }
 }
 
 /**
- * Stream a File as JSONL lines without building large intermediate arrays.
+ * Stream a Blob or ReadableStream as JSONL lines without building large intermediate arrays.
  *
  * Important:
  * - This does NOT trim whitespace: JSONL is line-delimited JSON; leading/trailing
@@ -36,13 +38,14 @@ function throwIfAborted(signal: AbortSignal | undefined) {
  * - Uses incremental newline scanning (avoids buffer.split("\n") blowups).
  */
 export async function* streamJsonlLines(
-  file: File,
+  source: JsonlByteSource,
   options: StreamJsonlOptions = {},
 ): AsyncGenerator<string> {
   const maxLineBytes = options.maxLineBytes ?? MAX_JSONL_LINE_BYTES;
   const { onProgress, signal } = options;
 
-  const reader = file.stream().getReader();
+  const stream = source instanceof ReadableStream ? source : source.stream();
+  const reader = stream.getReader();
 
   let bytesRead = 0;
   let linesEmitted = 0;

--- a/web/src/install/bundle_install.ts
+++ b/web/src/install/bundle_install.ts
@@ -1,0 +1,401 @@
+import { buildLanguageMetaFromManifest } from "../bundle_labels";
+import {
+  deriveBundleAssetUrls,
+  validateRemoteUrlPolicy,
+  type BundleCatalogEntryV1,
+} from "../bundle_catalog";
+import {
+  parseAndValidateManifestJson,
+  type BundleManifestV1,
+  type BundleManifestV1FileEntry,
+} from "../bundle_manifest";
+import {
+  clearBundleInstallSession,
+  deleteBundleScopeData,
+  getBundleStorageScopeId,
+  getInstalledBundleMeta,
+  recoverInterruptedBundleInstall,
+  setActiveBundleMeta,
+  setBundleInstallSession,
+  type ActiveBundleMeta,
+} from "../idb/siralex_db";
+import {
+  importRecordsJsonl,
+  type ImportRecordsProgress,
+} from "../import/import_records";
+import {
+  importSearchIndexJsonl,
+  type ImportSearchIndexProgress,
+} from "../import/import_search_index";
+import type { JsonlByteSource } from "../import/jsonl_stream";
+
+export const DEFAULT_BUNDLE_FETCH_TIMEOUT_MS = 30_000;
+
+export type InstallBundleResult = {
+  recordsCount: number;
+  indexCount: number;
+  elapsedMs: number;
+  cleanupWarning?: string;
+  skippedBecauseCurrent?: boolean;
+};
+
+export type InstallBundleSources = {
+  recordsSource: JsonlByteSource;
+  searchIndexSource: JsonlByteSource;
+};
+
+export type InstallRemoteBundleOptions = {
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  onUpdate?: (message: string) => void;
+  storageEstimate?: () => Promise<{ usage?: number; quota?: number }>;
+};
+
+function createLinkedAbortSignal(timeoutMs: number, externalSignal?: AbortSignal): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort(new Error(`Bundle request timed out after ${timeoutMs} ms`));
+  }, timeoutMs);
+
+  const onAbort = () => {
+    controller.abort(externalSignal?.reason ?? new Error("Bundle request aborted"));
+  };
+
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      onAbort();
+    } else {
+      externalSignal.addEventListener("abort", onAbort, { once: true });
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      externalSignal?.removeEventListener("abort", onAbort);
+    },
+  };
+}
+
+function getManifestFileEntry(manifest: BundleManifestV1, path: string): BundleManifestV1FileEntry {
+  const entry = manifest.files.find((file) => file.path === path);
+  if (!entry) {
+    throw new Error(`Manifest missing required payload entry: ${path}`);
+  }
+  return entry;
+}
+
+function createByteLengthValidatedStream(
+  source: ReadableStream<Uint8Array>,
+  expectedBytes: number,
+): ReadableStream<Uint8Array> {
+  let bytesRead = 0;
+  const reader = source.getReader();
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { value, done } = await reader.read();
+      if (done) {
+        if (bytesRead !== expectedBytes) {
+          controller.error(
+            new Error(`Remote payload byte_length mismatch: expected ${expectedBytes}, got ${bytesRead}`),
+          );
+          return;
+        }
+        controller.close();
+        return;
+      }
+      if (value) {
+        bytesRead += value.byteLength;
+        if (bytesRead > expectedBytes) {
+          controller.error(
+            new Error(`Remote payload byte_length mismatch: expected ${expectedBytes}, got at least ${bytesRead}`),
+          );
+          await reader.cancel().catch(() => undefined);
+          return;
+        }
+        controller.enqueue(value);
+      }
+    },
+    async cancel(reason) {
+      await reader.cancel(reason).catch(() => undefined);
+    },
+  });
+}
+
+async function fetchBodyStream(
+  url: string,
+  expectedBytes: number,
+  fetchImpl: typeof fetch,
+  signal: AbortSignal,
+  currentBaseUrl?: string,
+): Promise<ReadableStream<Uint8Array>> {
+  const response = await fetchImpl(url, {
+    headers: { Accept: "application/octet-stream,application/json,text/plain" },
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`Bundle request failed: ${response.status} ${response.statusText} (${url})`);
+  }
+  validateRemoteUrlPolicy(response.url || url, currentBaseUrl);
+
+  const contentLength = response.headers.get("content-length");
+  if (contentLength) {
+    const parsed = Number(contentLength);
+    if (Number.isFinite(parsed) && parsed !== expectedBytes) {
+      throw new Error(`Remote payload byte_length mismatch: expected ${expectedBytes}, got ${parsed}`);
+    }
+  }
+  if (!response.body) {
+    throw new Error(`Bundle response body missing for ${url}`);
+  }
+
+  return createByteLengthValidatedStream(response.body, expectedBytes);
+}
+
+function buildInstalledBundleMeta(
+  manifest: BundleManifestV1,
+  storageScopeId: string,
+  recordsCount: number,
+  indexCount: number,
+): ActiveBundleMeta {
+  return {
+    bundle_id: manifest.bundle_id,
+    storage_scope_id: storageScopeId,
+    manifest_schema_version: manifest.manifest_schema_version,
+    record_schema_id: manifest.record_schema_id,
+    record_schema_version: manifest.record_schema_version,
+    normalization_ruleset: manifest.rule_versions.normalization,
+    update_mode: manifest.update_mode,
+    reconciliation_action: manifest.reconciliation_action,
+    expected_content_sha256: manifest.content_sha256,
+    imported_at_iso: new Date().toISOString(),
+    records_count: recordsCount,
+    index_entries_count: indexCount,
+    language_meta: buildLanguageMetaFromManifest(manifest),
+  };
+}
+
+export async function installBundleIntoDb(
+  db: IDBDatabase,
+  manifest: BundleManifestV1,
+  sources: InstallBundleSources,
+  onUpdate: (message: string) => void,
+  signal?: AbortSignal,
+): Promise<InstallBundleResult> {
+  const recovered = await recoverInterruptedBundleInstall(db);
+  if (recovered) {
+    onUpdate(`${recovered}\n`);
+  }
+
+  const installedBefore = await getInstalledBundleMeta(db, manifest.bundle_id);
+  const previousStorageScopeId = installedBefore ? getBundleStorageScopeId(installedBefore) : undefined;
+  const nextStorageScopeId = `${manifest.bundle_id}::${manifest.content_sha256}`;
+
+  if (previousStorageScopeId === nextStorageScopeId) {
+    return {
+      recordsCount: installedBefore?.records_count ?? 0,
+      indexCount: installedBefore?.index_entries_count ?? 0,
+      elapsedMs: 0,
+      skippedBecauseCurrent: true,
+    };
+  }
+
+  await setBundleInstallSession(db, {
+    bundle_id: manifest.bundle_id,
+    storage_scope_id: nextStorageScopeId,
+    previous_storage_scope_id: previousStorageScopeId,
+    started_at_iso: new Date().toISOString(),
+    phase: "staging",
+  });
+
+  const t0 = performance.now();
+  let recordsCount = 0;
+  let indexCount = 0;
+  let cleanupWarning: string | undefined;
+  try {
+    const recRes = await importRecordsJsonl(db, sources.recordsSource, {
+      bundleId: nextStorageScopeId,
+      batchSize: 500,
+      signal,
+      onProgress: (p: ImportRecordsProgress) => {
+        onUpdate(
+          `Installing ${manifest.bundle_id}\n` +
+            `Stage: staging payloads\n\n` +
+            `[records.jsonl]\n` +
+            `bytes read: ${p.bytesRead}\n` +
+            `lines seen: ${p.linesSeen}\n` +
+            `records written: ${p.recordsWritten}\n` +
+            `batches committed: ${p.batchesCommitted}\n`,
+        );
+      },
+    });
+    recordsCount = recRes.recordsWritten;
+
+    const idxRes = await importSearchIndexJsonl(db, sources.searchIndexSource, {
+      bundleId: nextStorageScopeId,
+      batchSize: 500,
+      signal,
+      onProgress: (p: ImportSearchIndexProgress) => {
+        onUpdate(
+          `Installing ${manifest.bundle_id}\n` +
+            `Stage: staging payloads\n\n` +
+            `[records.jsonl] written: ${recordsCount}\n` +
+            `\n[search_index.jsonl]\n` +
+            `bytes read: ${p.bytesRead}\n` +
+            `lines seen: ${p.linesSeen}\n` +
+            `entries written: ${p.entriesWritten}\n` +
+            `batches committed: ${p.batchesCommitted}\n`,
+        );
+      },
+    });
+    indexCount = idxRes.entriesWritten;
+
+    await setActiveBundleMeta(db, buildInstalledBundleMeta(manifest, nextStorageScopeId, recordsCount, indexCount));
+    await setBundleInstallSession(db, {
+      bundle_id: manifest.bundle_id,
+      storage_scope_id: nextStorageScopeId,
+      previous_storage_scope_id: previousStorageScopeId,
+      started_at_iso: new Date().toISOString(),
+      phase: "committed",
+    });
+
+    if (previousStorageScopeId && previousStorageScopeId !== nextStorageScopeId) {
+      try {
+        await deleteBundleScopeData(db, previousStorageScopeId);
+        await clearBundleInstallSession(db);
+      } catch (e) {
+        cleanupWarning =
+          `New bundle is active, but previous bundle data cleanup did not complete: ${String(e)}\n` +
+          `Cleanup will be retried on next app load.`;
+      }
+    } else {
+      await clearBundleInstallSession(db);
+    }
+  } catch (e) {
+    await deleteBundleScopeData(db, nextStorageScopeId);
+    await clearBundleInstallSession(db);
+    throw e;
+  }
+
+  return {
+    recordsCount,
+    indexCount,
+    elapsedMs: performance.now() - t0,
+    cleanupWarning,
+  };
+}
+
+export async function installRemoteCatalogBundle(
+  db: IDBDatabase,
+  entry: BundleCatalogEntryV1,
+  catalogUrl: string,
+  options: InstallRemoteBundleOptions = {},
+): Promise<{ manifest: BundleManifestV1; result: InstallBundleResult }> {
+  const onUpdate = options.onUpdate ?? (() => undefined);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_BUNDLE_FETCH_TIMEOUT_MS;
+  const { signal, cleanup } = createLinkedAbortSignal(timeoutMs, options.signal);
+
+  try {
+    const urls = deriveBundleAssetUrls(catalogUrl, entry);
+    onUpdate(`Installing ${entry.bundle_id}\nStage: fetching manifest\n`);
+    const manifestResponse = await fetchImpl(urls.manifest_url, {
+      headers: { Accept: "application/json" },
+      signal,
+    });
+    if (!manifestResponse.ok) {
+      throw new Error(`Bundle request failed: ${manifestResponse.status} ${manifestResponse.statusText} (${urls.manifest_url})`);
+    }
+    validateRemoteUrlPolicy(manifestResponse.url || urls.manifest_url, catalogUrl);
+    const manifestText = await manifestResponse.text();
+    const parsed = parseAndValidateManifestJson(manifestText);
+    if (!parsed.ok || !parsed.manifest) {
+      throw new Error(`Manifest validation failed: ${parsed.errors.join("; ")}`);
+    }
+
+    const manifest = parsed.manifest;
+    if (manifest.bundle_id !== entry.bundle_id) {
+      throw new Error(
+        `Catalog/manifest bundle_id mismatch: catalog=${entry.bundle_id}, manifest=${manifest.bundle_id}`,
+      );
+    }
+    if (manifest.content_sha256 !== entry.content_sha256) {
+      throw new Error(
+        `Catalog/manifest content_sha256 mismatch: catalog=${entry.content_sha256}, manifest=${manifest.content_sha256}`,
+      );
+    }
+
+    const installed = await getInstalledBundleMeta(db, entry.bundle_id);
+    if (installed?.expected_content_sha256 === entry.content_sha256) {
+      await setActiveBundleMeta(
+        db,
+        {
+          ...installed,
+          imported_at_iso: installed.imported_at_iso,
+        },
+      );
+      return {
+        manifest,
+        result: {
+          recordsCount: installed.records_count ?? 0,
+          indexCount: installed.index_entries_count ?? 0,
+          elapsedMs: 0,
+          skippedBecauseCurrent: true,
+        },
+      };
+    }
+
+    const recordsEntry = getManifestFileEntry(manifest, "records.jsonl");
+    const indexEntry = getManifestFileEntry(manifest, "search_index.jsonl");
+
+    if (options.storageEstimate) {
+      const estimate = await options.storageEstimate();
+      const usage = estimate.usage ?? 0;
+      const quota = estimate.quota;
+      const requiredBytes = recordsEntry.byte_length + indexEntry.byte_length;
+      if (typeof quota === "number" && quota - usage < requiredBytes) {
+        throw new Error(
+          `Insufficient storage headroom: need ${requiredBytes} bytes, have ${Math.max(0, quota - usage)} bytes`,
+        );
+      }
+    }
+
+    onUpdate(`Installing ${entry.bundle_id}\nStage: fetching records.jsonl\n`);
+    const recordsStream = await fetchBodyStream(
+      urls.records_url,
+      recordsEntry.byte_length,
+      fetchImpl,
+      signal,
+      catalogUrl,
+    );
+    onUpdate(`Installing ${entry.bundle_id}\nStage: fetching search_index.jsonl\n`);
+    const indexStream = await fetchBodyStream(
+      urls.search_index_url,
+      indexEntry.byte_length,
+      fetchImpl,
+      signal,
+      catalogUrl,
+    );
+
+    const result = await installBundleIntoDb(
+      db,
+      manifest,
+      {
+        recordsSource: recordsStream,
+        searchIndexSource: indexStream,
+      },
+      onUpdate,
+      signal,
+    );
+
+    return { manifest, result };
+  } finally {
+    cleanup();
+  }
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -12,28 +12,39 @@ import {
   type SearchDirection,
 } from "./bundle_labels";
 import {
+  compareCatalogEntryToInstalled,
+  deriveBundleAssetUrls,
+  fetchBundleCatalog,
+  type BundleCatalogEntryV1,
+} from "./bundle_catalog";
+import {
   parseAndValidateManifestJson,
   validateSelectedFilesAgainstManifest,
   type BundleManifestV1,
 } from "./bundle_manifest";
 import {
-  clearActiveBundleId,
   deleteBundleData,
   deleteSiralexDb,
   getActiveBundleId,
   getActiveBundleMeta,
+  getBundleStorageScopeId,
+  getCachedBundleCatalog,
   getInstalledBundleMeta,
   listInstalledBundles,
   openSiralexDb,
+  recoverInterruptedBundleInstall,
+  setCachedBundleCatalog,
   setActiveBundleId,
-  setActiveBundleMeta,
   storeHasData,
   type ActiveBundleMeta,
+  type CachedBundleCatalog,
   STORE_RECORDS,
   STORE_SEARCH_INDEX,
 } from "./idb/siralex_db";
-import { importRecordsJsonl } from "./import/import_records";
-import { importSearchIndexJsonl } from "./import/import_search_index";
+import {
+  installBundleIntoDb,
+  installRemoteCatalogBundle,
+} from "./install/bundle_install";
 import { searchQuery } from "./search/search_query";
 import { resolveRecords } from "./search/resolve_records";
 import { renderResultsList } from "./render/render_results";
@@ -65,6 +76,15 @@ app.innerHTML = `
           </select>
         </div>
       </div>
+      <div class="row" style="margin-top: 12px; align-items: end">
+        <div class="field" style="flex: 1">
+          <div class="label">Catalog URL</div>
+          <input id="catalogUrl" type="text" placeholder="https://example.org/catalog.json or /catalog.json" autocomplete="off" />
+        </div>
+        <button id="loadCatalog" class="btn">Load catalog</button>
+      </div>
+      <div id="catalogStatus" class="mono" style="margin-top: 12px"></div>
+      <div id="catalogList" style="margin-top: 12px"></div>
       <div id="firstRun" style="display: none; margin-top: 12px">
         <p style="color: var(--muted); font-size: 14px; margin: 0 0 12px 0">
           No dictionary installed.<br>
@@ -74,6 +94,7 @@ app.innerHTML = `
       <div class="row" style="margin-top: 12px">
         <button id="quickImport" class="btn">Install bundle files</button>
         <input id="quickImportFiles" type="file" multiple accept=".json,.jsonl" style="display: none" />
+        <button id="cancelInstall" class="btn" style="display: none">Cancel install</button>
       </div>
       <div id="importProgress" class="mono" style="margin-top: 12px; display: none"></div>
       <div class="row" style="margin-top: 12px">
@@ -162,9 +183,14 @@ function mustGetEl<T extends Element>(selector: string): T {
 // Primary UI elements
 const dictStatus = mustGetEl<HTMLDivElement>("#dictStatus");
 const bundleSelect = mustGetEl<HTMLSelectElement>("#bundleSelect");
+const catalogUrlInput = mustGetEl<HTMLInputElement>("#catalogUrl");
+const loadCatalogBtn = mustGetEl<HTMLButtonElement>("#loadCatalog");
+const catalogStatus = mustGetEl<HTMLDivElement>("#catalogStatus");
+const catalogList = mustGetEl<HTMLDivElement>("#catalogList");
 const firstRun = mustGetEl<HTMLDivElement>("#firstRun");
 const quickImportBtn = mustGetEl<HTMLButtonElement>("#quickImport");
 const quickImportFiles = mustGetEl<HTMLInputElement>("#quickImportFiles");
+const cancelInstallBtn = mustGetEl<HTMLButtonElement>("#cancelInstall");
 const importProgress = mustGetEl<HTMLDivElement>("#importProgress");
 const clearDbBtn = mustGetEl<HTMLButtonElement>("#clearDb");
 const searchInput = mustGetEl<HTMLInputElement>("#searchInput");
@@ -190,6 +216,14 @@ let lastValidatedManifest: BundleManifestV1 | undefined;
 let busy = false;
 let installedBundles: ActiveBundleMeta[] = [];
 let currentActiveBundle: ActiveBundleMeta | undefined;
+let catalogLoading = false;
+let loadedCatalogBundles: BundleCatalogEntryV1[] = [];
+let loadedCatalogUrl: string | undefined;
+let loadedCatalogWarnings: string[] = [];
+let loadedCatalogFetchedAtIso: string | undefined;
+let loadedCatalogSource: "network" | "cache" | undefined;
+let remoteInstallAbortController: AbortController | undefined;
+let remoteInstallBundleId: string | undefined;
 
 function fmtBytes(n: number | undefined): string {
   if (n === undefined) return "n/a";
@@ -218,6 +252,53 @@ function updateButtons() {
   importBundleBtn.disabled = !lastValidatedManifest;
 }
 
+function updateCatalogControls() {
+  catalogUrlInput.disabled = busy || catalogLoading;
+  loadCatalogBtn.disabled = busy || catalogLoading || catalogUrlInput.value.trim() === "";
+}
+
+function updateInstallControls() {
+  const installInProgress = remoteInstallAbortController !== undefined;
+  cancelInstallBtn.style.display = installInProgress ? "" : "none";
+  cancelInstallBtn.disabled = !installInProgress;
+}
+
+function buildCachedCatalogSnapshot(
+  requestUrl: string,
+  responseUrl: string,
+  warnings: string[],
+  bundles: BundleCatalogEntryV1[],
+): CachedBundleCatalog {
+  return {
+    request_url: requestUrl,
+    response_url: responseUrl,
+    fetched_at_iso: new Date().toISOString(),
+    warnings,
+    catalog: {
+      catalog_schema_version: "bundle_catalog_v1",
+      bundles: bundles.map((bundle) => ({
+        bundle_id: bundle.bundle_id,
+        name: bundle.name,
+        version: bundle.version,
+        size_bytes: bundle.size_bytes,
+        url_base: bundle.url_base,
+        content_sha256: bundle.content_sha256,
+        language_meta: bundle.language_meta,
+      })),
+    },
+  };
+}
+
+function applyCachedCatalog(cached: CachedBundleCatalog, source: "network" | "cache") {
+  loadedCatalogBundles = cached.catalog.bundles;
+  loadedCatalogUrl = cached.response_url;
+  loadedCatalogWarnings = cached.warnings;
+  loadedCatalogFetchedAtIso = cached.fetched_at_iso;
+  loadedCatalogSource = source;
+  catalogUrlInput.value = cached.request_url;
+  updateCatalogControls();
+}
+
 function invalidateManifestValidation() {
   lastValidatedManifest = undefined;
   manifestOut.textContent = "";
@@ -236,6 +317,16 @@ manifestFile.addEventListener("change", () => {
   updateButtons();
 });
 updateButtons();
+updateCatalogControls();
+updateInstallControls();
+
+catalogUrlInput.addEventListener("input", () => {
+  updateCatalogControls();
+});
+
+cancelInstallBtn.addEventListener("click", () => {
+  remoteInstallAbortController?.abort(new Error(`Install cancelled by user for ${remoteInstallBundleId ?? "bundle"}`));
+});
 
 bundleSelect.addEventListener("change", () => {
   const nextBundleId = bundleSelect.value;
@@ -254,6 +345,136 @@ bundleSelect.addEventListener("change", () => {
 // --- Dictionary status ---
 
 let hasActiveBundle = false;
+
+function getCatalogPresentationState(entry: BundleCatalogEntryV1): {
+  badgeClass: string;
+  badgeLabel: string;
+  note?: string;
+} {
+  const installed = installedBundles.find((bundle) => bundle.bundle_id === entry.bundle_id);
+  const comparison = compareCatalogEntryToInstalled(entry, installed);
+  const isActive = currentActiveBundle?.bundle_id === entry.bundle_id;
+
+  if (comparison.state === "update_available") {
+    return {
+      badgeClass: "catalog-badge-update",
+      badgeLabel: "Update available",
+      note: isActive ? "Installed version is active on this device." : "Installed version differs from catalog hash.",
+    };
+  }
+
+  if (comparison.state === "installed_current") {
+    return {
+      badgeClass: isActive ? "catalog-badge-active" : "catalog-badge-installed",
+      badgeLabel: isActive ? "Active" : "Installed",
+      note: entry.version ? `Catalog version ${entry.version}` : undefined,
+    };
+  }
+
+  return {
+    badgeClass: "catalog-badge-available",
+    badgeLabel: "Available",
+  };
+}
+
+function getCatalogActionLabel(entry: BundleCatalogEntryV1): string {
+  const installed = installedBundles.find((bundle) => bundle.bundle_id === entry.bundle_id);
+  const comparison = compareCatalogEntryToInstalled(entry, installed);
+  if (currentActiveBundle?.bundle_id === entry.bundle_id && comparison.state === "installed_current") {
+    return "Active";
+  }
+  if (comparison.state === "update_available") return "Update";
+  if (comparison.state === "installed_current") return "Use installed";
+  return "Install";
+}
+
+function renderCatalogList() {
+  catalogList.innerHTML = "";
+
+  if (loadedCatalogBundles.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "catalog-empty";
+    empty.textContent = "No catalog loaded.";
+    catalogList.appendChild(empty);
+    return;
+  }
+
+  const list = document.createElement("div");
+  list.className = "catalog-list";
+
+  for (const entry of loadedCatalogBundles) {
+    const item = document.createElement("article");
+    item.className = "catalog-item";
+
+    const header = document.createElement("div");
+    header.className = "catalog-item-header";
+
+    const titleBlock = document.createElement("div");
+    const title = document.createElement("div");
+    title.className = "catalog-item-title";
+    title.textContent = entry.name;
+    const bundleId = document.createElement("div");
+    bundleId.className = "catalog-item-subtitle";
+    bundleId.textContent = entry.bundle_id;
+    titleBlock.append(title, bundleId);
+
+    const presentation = getCatalogPresentationState(entry);
+    const badge = document.createElement("span");
+    badge.className = `catalog-badge ${presentation.badgeClass}`;
+    badge.textContent = presentation.badgeLabel;
+    header.append(titleBlock, badge);
+
+    const meta = document.createElement("div");
+    meta.className = "catalog-item-meta";
+    const metaParts = [
+      entry.version ? `Version ${entry.version}` : undefined,
+      fmtBytes(entry.size_bytes),
+      `Hash ${entry.content_sha256}`,
+    ].filter((part): part is string => part !== undefined);
+    meta.textContent = metaParts.join(" | ");
+
+    const source = document.createElement("div");
+    source.className = "catalog-item-subtitle";
+    if (loadedCatalogUrl) {
+      const urls = deriveBundleAssetUrls(loadedCatalogUrl, entry);
+      source.textContent = `Bundle source: ${urls.base_url}`;
+      const files = document.createElement("div");
+      files.className = "catalog-item-subtitle";
+      files.textContent =
+        `Manifest: ${urls.manifest_url}\n` +
+        `Records: ${urls.records_url}\n` +
+        `Index: ${urls.search_index_url}`;
+      item.append(header, meta, source, files);
+    } else {
+      source.textContent = `Source base: ${entry.url_base}`;
+      item.append(header, meta, source);
+    }
+
+    if (presentation.note) {
+      const note = document.createElement("div");
+      note.className = "catalog-item-note";
+      note.textContent = presentation.note;
+      item.append(note);
+    }
+
+    const actions = document.createElement("div");
+    actions.className = "row";
+    const actionBtn = document.createElement("button");
+    actionBtn.className = "btn";
+    actionBtn.textContent = getCatalogActionLabel(entry);
+    actionBtn.disabled = busy || !loadedCatalogUrl || actionBtn.textContent === "Active";
+    actionBtn.addEventListener("click", () => {
+      void withSingleWriterLock(`install catalog bundle ${entry.bundle_id}`, async () => {
+        await installCatalogEntry(entry);
+      });
+    });
+    actions.appendChild(actionBtn);
+    item.append(actions);
+    list.appendChild(item);
+  }
+
+  catalogList.appendChild(list);
+}
 
 function renderBundleSelectOptions(activeBundleId: string | undefined) {
   bundleSelect.innerHTML = "";
@@ -340,7 +561,8 @@ async function refreshDbStatus() {
     dictStatus.textContent = `Database error: ${String(e)}\n`;
     dbOut.textContent = dictStatus.textContent;
   }
-  searchInput.disabled = !hasActiveBundle;
+  renderCatalogList();
+  searchInput.disabled = !hasActiveBundle || busy;
   langToggle.disabled = !hasActiveBundle || busy;
   if (!hasActiveBundle) {
     searchMeta.textContent = "";
@@ -354,6 +576,8 @@ async function refreshDbStatus() {
 async function withSingleWriterLock(label: string, fn: () => Promise<void>) {
   if (busy) return;
   busy = true;
+  clearTimeout(searchDebounceTimer);
+  searchSeq += 1;
   const prev = {
     validate: validateManifestBtn.disabled,
     importBundle: importBundleBtn.disabled,
@@ -363,6 +587,8 @@ async function withSingleWriterLock(label: string, fn: () => Promise<void>) {
     probeAll: probeAllBtn.disabled,
     quickImport: quickImportBtn.disabled,
     bundleSelect: bundleSelect.disabled,
+    loadCatalog: loadCatalogBtn.disabled,
+    catalogUrl: catalogUrlInput.disabled,
   };
   validateManifestBtn.disabled = true;
   importBundleBtn.disabled = true;
@@ -372,6 +598,10 @@ async function withSingleWriterLock(label: string, fn: () => Promise<void>) {
   probeAllBtn.disabled = true;
   quickImportBtn.disabled = true;
   bundleSelect.disabled = true;
+  loadCatalogBtn.disabled = true;
+  catalogUrlInput.disabled = true;
+  searchInput.disabled = true;
+  langToggle.disabled = true;
   try {
     await fn();
   } finally {
@@ -384,89 +614,12 @@ async function withSingleWriterLock(label: string, fn: () => Promise<void>) {
     probeAllBtn.disabled = prev.probeAll;
     quickImportBtn.disabled = prev.quickImport;
     bundleSelect.disabled = prev.bundleSelect;
+    loadCatalogBtn.disabled = prev.loadCatalog;
+    catalogUrlInput.disabled = prev.catalogUrl;
     updateButtons();
+    updateCatalogControls();
     await refreshDbStatus();
   }
-}
-
-function buildInstalledBundleMeta(
-  manifest: BundleManifestV1,
-  recordsCount: number,
-  indexCount: number,
-): ActiveBundleMeta {
-  return {
-    bundle_id: manifest.bundle_id,
-    manifest_schema_version: manifest.manifest_schema_version,
-    record_schema_id: manifest.record_schema_id,
-    record_schema_version: manifest.record_schema_version,
-    normalization_ruleset: manifest.rule_versions.normalization,
-    update_mode: manifest.update_mode,
-    reconciliation_action: manifest.reconciliation_action,
-    expected_content_sha256: manifest.content_sha256,
-    imported_at_iso: new Date().toISOString(),
-    records_count: recordsCount,
-    index_entries_count: indexCount,
-    language_meta: buildLanguageMetaFromManifest(manifest),
-  };
-}
-
-async function installBundleIntoDb(
-  db: IDBDatabase,
-  manifest: BundleManifestV1,
-  records: File,
-  searchIndex: File,
-  onUpdate: (message: string) => void,
-): Promise<{ recordsCount: number; indexCount: number; elapsedMs: number }> {
-  await deleteBundleData(db, manifest.bundle_id);
-
-  const t0 = performance.now();
-  let recordsCount = 0;
-  let indexCount = 0;
-  try {
-    const recRes = await importRecordsJsonl(db, records, {
-      bundleId: manifest.bundle_id,
-      batchSize: 500,
-      onProgress: (p) => {
-        onUpdate(
-          `Installing ${manifest.bundle_id}\n\n` +
-            `[records.jsonl]\n` +
-            `bytes read: ${p.bytesRead}\n` +
-            `lines seen: ${p.linesSeen}\n` +
-            `records written: ${p.recordsWritten}\n` +
-            `batches committed: ${p.batchesCommitted}\n`,
-        );
-      },
-    });
-    recordsCount = recRes.recordsWritten;
-
-    const idxRes = await importSearchIndexJsonl(db, searchIndex, {
-      bundleId: manifest.bundle_id,
-      batchSize: 500,
-      onProgress: (p) => {
-        onUpdate(
-          `Installing ${manifest.bundle_id}\n\n` +
-            `[records.jsonl] written: ${recordsCount}\n` +
-            `\n[search_index.jsonl]\n` +
-            `bytes read: ${p.bytesRead}\n` +
-            `lines seen: ${p.linesSeen}\n` +
-            `entries written: ${p.entriesWritten}\n` +
-            `batches committed: ${p.batchesCommitted}\n`,
-        );
-      },
-    });
-    indexCount = idxRes.entriesWritten;
-
-    await setActiveBundleMeta(db, buildInstalledBundleMeta(manifest, recordsCount, indexCount));
-  } catch (e) {
-    await deleteBundleData(db, manifest.bundle_id);
-    throw e;
-  }
-
-  return {
-    recordsCount,
-    indexCount,
-    elapsedMs: performance.now() - t0,
-  };
 }
 
 // --- Quick import (single-action file picker) ---
@@ -533,11 +686,17 @@ async function quickImportBundle(fileList: FileList) {
     const existingDb = await openSiralexDb();
     const installed = await getInstalledBundleMeta(existingDb, mfst.bundle_id);
     if (installed) {
-      await setActiveBundleId(existingDb, mfst.bundle_id);
-      existingDb.close();
-      importProgress.textContent = `Bundle already installed. Marked active: ${mfst.bundle_id}\n`;
-      await refreshDbStatus();
-      return;
+      if (installed.expected_content_sha256 === mfst.content_sha256) {
+        await setActiveBundleId(existingDb, mfst.bundle_id);
+        existingDb.close();
+        importProgress.textContent = `Bundle already installed. Marked active: ${mfst.bundle_id}\n`;
+        await refreshDbStatus();
+        return;
+      }
+      importProgress.textContent =
+        `Updating installed bundle ${mfst.bundle_id}.\n` +
+        `Existing hash: ${installed.expected_content_sha256 ?? "unknown"}\n` +
+        `New hash: ${mfst.content_sha256}\n`;
     }
     existingDb.close();
   } catch {
@@ -552,8 +711,10 @@ async function quickImportBundle(fileList: FileList) {
     const result = await installBundleIntoDb(
       db,
       mfst,
-      recordsFileObj!,
-      searchIndexFileObj!,
+      {
+        recordsSource: recordsFileObj!,
+        searchIndexSource: searchIndexFileObj!,
+      },
       (message) => {
         importProgress.textContent = message;
       },
@@ -562,6 +723,9 @@ async function quickImportBundle(fileList: FileList) {
       `Install complete: ${mfst.bundle_id}\n` +
       `${result.recordsCount} records, ${result.indexCount} index entries\n` +
       `${result.elapsedMs.toFixed(0)} ms\n`;
+    if (result.cleanupWarning) {
+      importProgress.textContent += `\n${result.cleanupWarning}\n`;
+    }
   } catch (e) {
     importProgress.textContent += `\nImport failed: ${String(e)}\n`;
     importProgress.textContent += `Partial bundle data removed. Re-import required.\n`;
@@ -569,6 +733,142 @@ async function quickImportBundle(fileList: FileList) {
     db.close();
   }
 }
+
+// --- Catalog loading (Phase 4.1) ---
+
+async function loadCatalogFromUrl() {
+  const catalogUrl = catalogUrlInput.value.trim();
+  if (catalogUrl === "") return;
+
+  catalogLoading = true;
+  updateCatalogControls();
+  catalogStatus.textContent = `Loading catalog from ${catalogUrl}...\n`;
+
+  try {
+    const result = await fetchBundleCatalog(catalogUrl, {
+      baseUrl: window.location.href,
+    });
+    const cached = buildCachedCatalogSnapshot(
+      result.requestUrl,
+      result.responseUrl,
+      result.warnings,
+      result.catalog.bundles,
+    );
+    const db = await openSiralexDb();
+    try {
+      await setCachedBundleCatalog(db, cached);
+    } finally {
+      db.close();
+    }
+    applyCachedCatalog(cached, "network");
+    catalogStatus.textContent =
+      `Catalog loaded.\n` +
+      `Source: ${result.responseUrl}\n` +
+      `Bundles: ${result.catalog.bundles.length}\n` +
+      `Fetched at: ${cached.fetched_at_iso}\n` +
+      `Remote policy: https anywhere; http only for same-origin or local hubs (localhost, .local, private IPs).\n` +
+      `Bundle URL contract: url_base + bundle.manifest.json / records.jsonl / search_index.jsonl\n`;
+    for (const warning of result.warnings) {
+      catalogStatus.textContent += `WARN: ${warning}\n`;
+    }
+  } catch (e) {
+    catalogStatus.textContent = `Catalog load failed: ${String(e)}\n`;
+    if (loadedCatalogBundles.length > 0 && loadedCatalogUrl && loadedCatalogFetchedAtIso) {
+      catalogStatus.textContent +=
+        `Showing cached catalog from ${loadedCatalogUrl}\n` +
+        `Fetched at: ${loadedCatalogFetchedAtIso}\n`;
+    }
+  } finally {
+    catalogLoading = false;
+    updateCatalogControls();
+    renderCatalogList();
+  }
+}
+
+async function restoreCachedCatalogFromDb() {
+  const db = await openSiralexDb();
+  try {
+    const cached = await getCachedBundleCatalog(db);
+    if (!cached) return;
+    applyCachedCatalog(cached, "cache");
+    catalogStatus.textContent =
+      `Cached catalog restored.\n` +
+      `Source: ${cached.response_url}\n` +
+      `Fetched at: ${cached.fetched_at_iso}\n` +
+      `Load catalog to refresh from the network.\n`;
+    for (const warning of cached.warnings) {
+      catalogStatus.textContent += `WARN: ${warning}\n`;
+    }
+  } finally {
+    db.close();
+  }
+}
+
+async function installCatalogEntry(entry: BundleCatalogEntryV1) {
+  if (!loadedCatalogUrl) {
+    importProgress.style.display = "";
+    importProgress.textContent = "No catalog source URL is available for this entry.\n";
+    return;
+  }
+
+  const existingDb = await openSiralexDb();
+  try {
+    const installed = await getInstalledBundleMeta(existingDb, entry.bundle_id);
+    if (installed?.expected_content_sha256 === entry.content_sha256) {
+      await setActiveBundleId(existingDb, entry.bundle_id);
+      importProgress.style.display = "";
+      importProgress.textContent = `Bundle already installed. Marked active: ${entry.bundle_id}\n`;
+      return;
+    }
+  } finally {
+    existingDb.close();
+  }
+
+  const controller = new AbortController();
+  remoteInstallAbortController = controller;
+  remoteInstallBundleId = entry.bundle_id;
+  updateInstallControls();
+  importProgress.style.display = "";
+  importProgress.textContent = `Preparing remote install for ${entry.bundle_id}...\n`;
+
+  const db = await openSiralexDb();
+  try {
+    const { manifest, result } = await installRemoteCatalogBundle(db, entry, loadedCatalogUrl, {
+      signal: controller.signal,
+      onUpdate: (message) => {
+        importProgress.textContent = message;
+      },
+      storageEstimate:
+        typeof navigator !== "undefined" && navigator.storage?.estimate
+          ? async () => await navigator.storage.estimate()
+          : undefined,
+    });
+
+    if (result.skippedBecauseCurrent) {
+      await setActiveBundleId(db, manifest.bundle_id);
+      importProgress.textContent = `Bundle already installed. Marked active: ${manifest.bundle_id}\n`;
+    } else {
+      importProgress.textContent =
+        `Remote install complete: ${manifest.bundle_id}\n` +
+        `${result.recordsCount} records, ${result.indexCount} index entries\n` +
+        `${result.elapsedMs.toFixed(0)} ms\n`;
+      if (result.cleanupWarning) {
+        importProgress.textContent += `\n${result.cleanupWarning}\n`;
+      }
+    }
+  } catch (e) {
+    importProgress.textContent = `Remote install failed: ${String(e)}\n`;
+  } finally {
+    remoteInstallAbortController = undefined;
+    remoteInstallBundleId = undefined;
+    updateInstallControls();
+    db.close();
+  }
+}
+
+loadCatalogBtn.addEventListener("click", () => {
+  void loadCatalogFromUrl();
+});
 
 // --- Developer tools: manifest validation ---
 
@@ -635,10 +935,16 @@ importBundleBtn.addEventListener("click", () => {
       const existingDb = await openSiralexDb();
       const installed = await getInstalledBundleMeta(existingDb, mfst.bundle_id);
       if (installed) {
-        await setActiveBundleId(existingDb, mfst.bundle_id);
-        existingDb.close();
-        dbOut.textContent = `Bundle already installed. Marked active: ${mfst.bundle_id}\n`;
-        return;
+        if (installed.expected_content_sha256 === mfst.content_sha256) {
+          await setActiveBundleId(existingDb, mfst.bundle_id);
+          existingDb.close();
+          dbOut.textContent = `Bundle already installed. Marked active: ${mfst.bundle_id}\n`;
+          return;
+        }
+        dbOut.textContent =
+          `Updating installed bundle ${mfst.bundle_id}.\n` +
+          `Existing hash: ${installed.expected_content_sha256 ?? "unknown"}\n` +
+          `New hash: ${mfst.content_sha256}\n`;
       }
       existingDb.close();
     } catch {
@@ -648,9 +954,17 @@ importBundleBtn.addEventListener("click", () => {
     const db = await openSiralexDb();
     try {
       dbOut.textContent = `Installing bundle ${mfst.bundle_id}...\n`;
-      const result = await installBundleIntoDb(db, mfst, rf, ix, (message) => {
-        dbOut.textContent = message;
-      });
+      const result = await installBundleIntoDb(
+        db,
+        mfst,
+        {
+          recordsSource: rf,
+          searchIndexSource: ix,
+        },
+        (message) => {
+          dbOut.textContent = message;
+        },
+      );
       dbOut.textContent =
         `Install COMPLETE\n` +
         `bundle_id: ${mfst.bundle_id}\n` +
@@ -658,6 +972,9 @@ importBundleBtn.addEventListener("click", () => {
         `index entries: ${result.indexCount}\n` +
         `elapsed: ${result.elapsedMs.toFixed(0)} ms\n` +
         `\nNote: expected_content_sha256 stored from manifest; NOT verified client-side.\n`;
+      if (result.cleanupWarning) {
+        dbOut.textContent += `\n${result.cleanupWarning}\n`;
+      }
     } catch (e) {
       dbOut.textContent += `\nImport FAILED: ${String(e)}\n`;
       dbOut.textContent += `Partial bundle data was removed. Please re-validate and re-import.\n`;
@@ -814,6 +1131,10 @@ function showEntryDetail(record: EnrichedRecord) {
 }
 
 async function runSearch(query: string) {
+  if (busy) {
+    searchMeta.textContent = "Search temporarily unavailable during install/update.";
+    return;
+  }
   if (!hasActiveBundle) {
     searchMeta.textContent = "Search disabled: no active bundle.";
     return;
@@ -823,15 +1144,16 @@ async function runSearch(query: string) {
   let db: IDBDatabase | undefined;
   try {
     db = await openSiralexDb();
-    const activeBundleId = await getActiveBundleId(db);
-    if (!activeBundleId) {
+    const activeBundleMeta = await getActiveBundleMeta(db);
+    if (!activeBundleMeta) {
       searchMeta.textContent = "Search disabled: no active bundle.";
       searchResults.innerHTML = "";
       lastSearchRecords = [];
       return;
     }
+    const activeStorageScopeId = getBundleStorageScopeId(activeBundleMeta);
 
-    const result = await searchQuery(db, activeBundleId, query);
+    const result = await searchQuery(db, activeStorageScopeId, query);
     if (seq !== searchSeq) return;
 
     if (result.ir_ids.length === 0) {
@@ -843,7 +1165,7 @@ async function runSearch(query: string) {
       return;
     }
 
-    const records = await resolveRecords(db, activeBundleId, result.ir_ids);
+    const records = await resolveRecords(db, activeStorageScopeId, result.ir_ids);
     if (seq !== searchSeq) return;
     const elapsedMs = performance.now() - t0;
 
@@ -863,4 +1185,21 @@ async function runSearch(query: string) {
   }
 }
 
-void refreshDbStatus();
+async function initializeAppState() {
+  let recoveryMessage: string | undefined;
+  const db = await openSiralexDb();
+  try {
+    recoveryMessage = await recoverInterruptedBundleInstall(db);
+  } finally {
+    db.close();
+  }
+
+  await restoreCachedCatalogFromDb();
+  if (recoveryMessage) {
+    importProgress.style.display = "";
+    importProgress.textContent = `${recoveryMessage}\n`;
+  }
+  await refreshDbStatus();
+}
+
+void initializeAppState();

--- a/web/src/phase3_bundle_runtime.test.ts
+++ b/web/src/phase3_bundle_runtime.test.ts
@@ -4,11 +4,14 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { parseAndValidateManifestJson } from "./bundle_manifest";
 import {
+  deleteBundleData,
   deleteSiralexDb,
   getActiveBundleId,
   getActiveBundleMeta,
   listInstalledBundles,
   openSiralexDb,
+  recoverInterruptedBundleInstall,
+  setBundleInstallSession,
   setActiveBundleId,
   setActiveBundleMeta,
 } from "./idb/siralex_db";
@@ -295,6 +298,93 @@ describe("Phase 3 bundle-aware runtime", () => {
       expect(result.ir_ids).toEqual(["rec-a"]);
       const records = await resolveRecords(db, "bundle_full_a_aaaaaaaa", result.ir_ids);
       expect(records.map((record) => record.ir_id)).toEqual(["rec-a"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("deletes data using storage_scope_id from the registry", async () => {
+    const db = await openSiralexDb();
+    try {
+      await importRecordsJsonl(
+        db,
+        makeJsonlFile("records.jsonl", [
+          {
+            ir_id: "rec-staged",
+            ir_kind: "lexicon_entry",
+            source_id: "src_staged",
+            norm_version: "norm_v1",
+            preferred_form: "hello",
+            variant_forms: ["hello"],
+            search_keys: { casefold: ["hello"] },
+            display: { headword_latin: "hello" },
+          },
+        ]),
+        { bundleId: "bundle_a::sha256:new", batchSize: 10 },
+      );
+      await importSearchIndexJsonl(
+        db,
+        makeJsonlFile("search_index.jsonl", [
+          { key_type: "casefold", key: "hello", ir_ids: ["rec-staged"] },
+        ]),
+        { bundleId: "bundle_a::sha256:new", batchSize: 10 },
+      );
+      await setActiveBundleMeta(db, {
+        bundle_id: "bundle_a",
+        storage_scope_id: "bundle_a::sha256:new",
+        manifest_schema_version: "bundle_manifest_v1",
+        record_schema_id: "normalized_v1",
+        record_schema_version: "1",
+        normalization_ruleset: "norm_v1",
+        update_mode: "REPLACE_ALL",
+        reconciliation_action: "REPLACE_ALL",
+        imported_at_iso: "2026-03-10T00:00:00Z",
+      });
+
+      let result = await searchQuery(db, "bundle_a::sha256:new", "hello");
+      expect(result.ir_ids).toEqual(["rec-staged"]);
+
+      await deleteBundleData(db, "bundle_a");
+
+      result = await searchQuery(db, "bundle_a::sha256:new", "hello");
+      expect(result.ir_ids).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("recovers interrupted committed installs by cleaning previous storage scope", async () => {
+    const db = await openSiralexDb();
+    try {
+      await importRecordsJsonl(
+        db,
+        makeJsonlFile("records.jsonl", [
+          {
+            ir_id: "rec-old",
+            ir_kind: "lexicon_entry",
+            source_id: "src_old",
+            norm_version: "norm_v1",
+            preferred_form: "old",
+            variant_forms: ["old"],
+            search_keys: { casefold: ["old"] },
+            display: { headword_latin: "old" },
+          },
+        ]),
+        { bundleId: "bundle_a", batchSize: 10 },
+      );
+      await setBundleInstallSession(db, {
+        bundle_id: "bundle_a",
+        storage_scope_id: "bundle_a::sha256:new",
+        previous_storage_scope_id: "bundle_a",
+        started_at_iso: "2026-03-10T00:00:00Z",
+        phase: "committed",
+      });
+
+      const message = await recoverInterruptedBundleInstall(db);
+      expect(message).toContain("Recovered committed install");
+
+      const result = await searchQuery(db, "bundle_a", "old");
+      expect(result.ir_ids).toEqual([]);
     } finally {
       db.close();
     }

--- a/web/src/phase4_remote_install.test.ts
+++ b/web/src/phase4_remote_install.test.ts
@@ -1,0 +1,533 @@
+import "fake-indexeddb/auto";
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { BundleCatalogEntryV1 } from "./bundle_catalog";
+import {
+  deleteSiralexDb,
+  getActiveBundleMeta,
+  getBundleInstallSession,
+  getInstalledBundleMeta,
+  openSiralexDb,
+  recoverInterruptedBundleInstall,
+  setActiveBundleMeta,
+} from "./idb/siralex_db";
+import { importRecordsJsonl } from "./import/import_records";
+import { importSearchIndexJsonl } from "./import/import_search_index";
+import { installRemoteCatalogBundle } from "./install/bundle_install";
+import { resolveRecords } from "./search/resolve_records";
+import { searchQuery } from "./search/search_query";
+
+function makeJsonl(rows: unknown[]): string {
+  return rows.map((row) => JSON.stringify(row)).join("\n") + "\n";
+}
+
+function makeStream(text: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes.subarray(0, Math.ceil(bytes.length / 2)));
+      controller.enqueue(bytes.subarray(Math.ceil(bytes.length / 2)));
+      controller.close();
+    },
+  });
+}
+
+function makeLineChunkedStream(text: string): ReadableStream<Uint8Array> {
+  const lines = text.match(/[^\n]*\n|[^\n]+$/g) ?? [];
+  const encoder = new TextEncoder();
+  let index = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index >= lines.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(encoder.encode(lines[index]!));
+      index += 1;
+    },
+  });
+}
+
+function makeResponse(body: string, contentType: string): Response {
+  const bytes = new TextEncoder().encode(body);
+  return new Response(makeStream(body), {
+    status: 200,
+    headers: {
+      "content-type": contentType,
+      "content-length": String(bytes.byteLength),
+    },
+  });
+}
+
+function makeResponseWithUrl(body: string, contentType: string, url: string, chunked = false): Response {
+  const bytes = new TextEncoder().encode(body);
+  const response = new Response(chunked ? makeLineChunkedStream(body) : makeStream(body), {
+    status: 200,
+    headers: {
+      "content-type": contentType,
+      "content-length": String(bytes.byteLength),
+    },
+  });
+  Object.defineProperty(response, "url", {
+    value: url,
+    configurable: true,
+  });
+  return response;
+}
+
+async function seedInstalledBundleScope(
+  db: IDBDatabase,
+  storageScopeId: string,
+  preferredForm: string,
+  lookupKey: string,
+): Promise<void> {
+  await importRecordsJsonl(
+    db,
+    new Blob([
+      makeJsonl([
+        {
+          ir_id: `${storageScopeId}-rec`,
+          ir_kind: "lexicon_entry",
+          source_id: `${storageScopeId}-src`,
+          norm_version: "norm_v1",
+          preferred_form: preferredForm,
+          variant_forms: [preferredForm],
+          search_keys: { casefold: [lookupKey] },
+          display: { headword_latin: preferredForm },
+        },
+      ]),
+    ]),
+    { bundleId: storageScopeId, batchSize: 10 },
+  );
+  await importSearchIndexJsonl(
+    db,
+    new Blob([makeJsonl([{ key_type: "casefold", key: lookupKey, ir_ids: [`${storageScopeId}-rec`] }])]),
+    { bundleId: storageScopeId, batchSize: 10 },
+  );
+}
+
+describe("Phase 4.2 remote install", () => {
+  beforeEach(async () => {
+    try {
+      await deleteSiralexDb();
+    } catch {
+      // ignore
+    }
+  });
+
+  it("streams remote bundle payloads into staged install and activates the new storage scope", async () => {
+    const recordsText = makeJsonl([
+      {
+        ir_id: "rec-1",
+        ir_kind: "lexicon_entry",
+        source_id: "src_1",
+        norm_version: "norm_v1",
+        preferred_form: "bonjour",
+        variant_forms: ["bonjour"],
+        search_keys: { casefold: ["hello"] },
+        display: { headword_latin: "bonjour" },
+      },
+    ]);
+    const indexText = makeJsonl([{ key_type: "casefold", key: "hello", ir_ids: ["rec-1"] }]);
+    const manifestText = JSON.stringify({
+      manifest_schema_version: "bundle_manifest_v1",
+      bundle_id: "maninka_fr_v1",
+      bundle_type: "full",
+      bundle_format: "directory",
+      compression: "none",
+      record_schema_id: "normalized_v1",
+      record_schema_version: "1",
+      rule_versions: { normalization: "norm_v1" },
+      sources: { included: ["src"], excluded: [] },
+      reconciliation_action: "REPLACE_ALL",
+      update_mode: "REPLACE_ALL",
+      files: [
+        {
+          path: "records.jsonl",
+          byte_length: new TextEncoder().encode(recordsText).byteLength,
+          sha256: "sha256:records",
+        },
+        {
+          path: "search_index.jsonl",
+          byte_length: new TextEncoder().encode(indexText).byteLength,
+          sha256: "sha256:index",
+        },
+      ],
+      content_sha256: "sha256:bundle",
+      languages: { source_lang: "fr", target_lang: "mnk" },
+      language_labels: { source: "French", target: "Maninka" },
+    });
+
+    const entry: BundleCatalogEntryV1 = {
+      bundle_id: "maninka_fr_v1",
+      name: "French ↔ Maninka",
+      version: "1.0.0",
+      size_bytes: new TextEncoder().encode(recordsText).byteLength + new TextEncoder().encode(indexText).byteLength,
+      url_base: "./bundles/maninka_fr_v1/",
+      content_sha256: "sha256:bundle",
+      language_meta: {
+        source_lang: "fr",
+        target_lang: "mnk",
+        source_label: "French",
+        target_label: "Maninka",
+      },
+    };
+
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = String(input);
+      if (url.endsWith("/bundle.manifest.json")) return makeResponse(manifestText, "application/json");
+      if (url.endsWith("/records.jsonl")) return makeResponse(recordsText, "application/json");
+      if (url.endsWith("/search_index.jsonl")) return makeResponse(indexText, "application/json");
+      return new Response("not found", { status: 404, statusText: "Not Found" });
+    };
+
+    const db = await openSiralexDb();
+    try {
+      const { manifest, result } = await installRemoteCatalogBundle(
+        db,
+        entry,
+        "https://example.test/catalog.json",
+        { fetchImpl },
+      );
+
+      expect(manifest.bundle_id).toBe("maninka_fr_v1");
+      expect(result.recordsCount).toBe(1);
+      expect(result.indexCount).toBe(1);
+
+      const active = await getActiveBundleMeta(db);
+      expect(active?.bundle_id).toBe("maninka_fr_v1");
+      expect(active?.storage_scope_id).toBe("maninka_fr_v1::sha256:bundle");
+
+      const installed = await getInstalledBundleMeta(db, "maninka_fr_v1");
+      expect(installed?.expected_content_sha256).toBe("sha256:bundle");
+
+      const resultIds = await searchQuery(db, active!.storage_scope_id!, "hello");
+      expect(resultIds.ir_ids).toEqual(["rec-1"]);
+      const records = await resolveRecords(db, active!.storage_scope_id!, resultIds.ir_ids);
+      expect(records.map((record) => record.ir_id)).toEqual(["rec-1"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rejects catalog/manifest hash mismatches before payload import", async () => {
+    const manifestText = JSON.stringify({
+      manifest_schema_version: "bundle_manifest_v1",
+      bundle_id: "maninka_fr_v1",
+      bundle_type: "full",
+      bundle_format: "directory",
+      compression: "none",
+      record_schema_id: "normalized_v1",
+      record_schema_version: "1",
+      rule_versions: { normalization: "norm_v1" },
+      sources: { included: ["src"], excluded: [] },
+      reconciliation_action: "REPLACE_ALL",
+      update_mode: "REPLACE_ALL",
+      files: [
+        { path: "records.jsonl", byte_length: 1, sha256: "sha256:records" },
+        { path: "search_index.jsonl", byte_length: 1, sha256: "sha256:index" },
+      ],
+      content_sha256: "sha256:manifest",
+    });
+
+    const entry: BundleCatalogEntryV1 = {
+      bundle_id: "maninka_fr_v1",
+      name: "French ↔ Maninka",
+      size_bytes: 2,
+      url_base: "./bundles/maninka_fr_v1/",
+      content_sha256: "sha256:catalog",
+    };
+
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = String(input);
+      if (url.endsWith("/bundle.manifest.json")) return makeResponse(manifestText, "application/json");
+      return new Response("unexpected", { status: 500 });
+    };
+
+    const db = await openSiralexDb();
+    try {
+      await expect(
+        installRemoteCatalogBundle(db, entry, "https://example.test/catalog.json", { fetchImpl }),
+      ).rejects.toThrow("Catalog/manifest content_sha256 mismatch");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rejects manifest redirects to disallowed final URLs", async () => {
+    const manifestText = JSON.stringify({
+      manifest_schema_version: "bundle_manifest_v1",
+      bundle_id: "maninka_fr_v1",
+      bundle_type: "full",
+      bundle_format: "directory",
+      compression: "none",
+      record_schema_id: "normalized_v1",
+      record_schema_version: "1",
+      rule_versions: { normalization: "norm_v1" },
+      sources: { included: ["src"], excluded: [] },
+      reconciliation_action: "REPLACE_ALL",
+      update_mode: "REPLACE_ALL",
+      files: [
+        { path: "records.jsonl", byte_length: 1, sha256: "sha256:records" },
+        { path: "search_index.jsonl", byte_length: 1, sha256: "sha256:index" },
+      ],
+      content_sha256: "sha256:bundle",
+    });
+
+    const entry: BundleCatalogEntryV1 = {
+      bundle_id: "maninka_fr_v1",
+      name: "French ↔ Maninka",
+      size_bytes: 2,
+      url_base: "./bundles/maninka_fr_v1/",
+      content_sha256: "sha256:bundle",
+    };
+
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = String(input);
+      if (url.endsWith("/bundle.manifest.json")) {
+        return makeResponseWithUrl(manifestText, "application/json", "http://evil.example/manifest.json");
+      }
+      return new Response("unexpected", { status: 500 });
+    };
+
+    const db = await openSiralexDb();
+    try {
+      await expect(
+        installRemoteCatalogBundle(db, entry, "https://example.test/catalog.json", { fetchImpl }),
+      ).rejects.toThrow("Remote http: URLs are only allowed for same-origin or local hosts");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("cancels during records import and cleans staged state", async () => {
+    const oldScope = "maninka_fr_v1::sha256:old";
+    const newScope = "maninka_fr_v1::sha256:new";
+    const recordsText = makeJsonl(
+      Array.from({ length: 4 }, (_, index) => ({
+        ir_id: `new-rec-${index + 1}`,
+        ir_kind: "lexicon_entry",
+        source_id: `new-src-${index + 1}`,
+        norm_version: "norm_v1",
+        preferred_form: `new-${index + 1}`,
+        variant_forms: [`new-${index + 1}`],
+        search_keys: { casefold: ["hello"] },
+        display: { headword_latin: `new-${index + 1}` },
+      })),
+    );
+    const indexText = makeJsonl(
+      Array.from({ length: 4 }, (_, index) => ({
+        key_type: "casefold",
+        key: `hello-${index + 1}`,
+        ir_ids: [`new-rec-${index + 1}`],
+      })),
+    );
+    const manifestText = JSON.stringify({
+      manifest_schema_version: "bundle_manifest_v1",
+      bundle_id: "maninka_fr_v1",
+      bundle_type: "full",
+      bundle_format: "directory",
+      compression: "none",
+      record_schema_id: "normalized_v1",
+      record_schema_version: "1",
+      rule_versions: { normalization: "norm_v1" },
+      sources: { included: ["src"], excluded: [] },
+      reconciliation_action: "REPLACE_ALL",
+      update_mode: "REPLACE_ALL",
+      files: [
+        {
+          path: "records.jsonl",
+          byte_length: new TextEncoder().encode(recordsText).byteLength,
+          sha256: "sha256:records",
+        },
+        {
+          path: "search_index.jsonl",
+          byte_length: new TextEncoder().encode(indexText).byteLength,
+          sha256: "sha256:index",
+        },
+      ],
+      content_sha256: "sha256:new",
+    });
+    const entry: BundleCatalogEntryV1 = {
+      bundle_id: "maninka_fr_v1",
+      name: "French ↔ Maninka",
+      size_bytes: new TextEncoder().encode(recordsText).byteLength + new TextEncoder().encode(indexText).byteLength,
+      url_base: "./bundles/maninka_fr_v1/",
+      content_sha256: "sha256:new",
+    };
+    const controller = new AbortController();
+    let aborted = false;
+
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/bundle.manifest.json")) {
+        return makeResponseWithUrl(manifestText, "application/json", url);
+      }
+      if (url.endsWith("/records.jsonl")) {
+        return makeResponseWithUrl(recordsText, "application/json", url, true);
+      }
+      if (url.endsWith("/search_index.jsonl")) {
+        return makeResponseWithUrl(indexText, "application/json", url, true);
+      }
+      throw init?.signal?.reason ?? new Error("unexpected fetch");
+    };
+
+    const db = await openSiralexDb();
+    try {
+      await seedInstalledBundleScope(db, oldScope, "old-entry", "hello");
+      await setActiveBundleMeta(db, {
+        bundle_id: "maninka_fr_v1",
+        storage_scope_id: oldScope,
+        manifest_schema_version: "bundle_manifest_v1",
+        record_schema_id: "normalized_v1",
+        record_schema_version: "1",
+        normalization_ruleset: "norm_v1",
+        update_mode: "REPLACE_ALL",
+        reconciliation_action: "REPLACE_ALL",
+        expected_content_sha256: "sha256:old",
+        imported_at_iso: "2026-03-11T00:00:00Z",
+        records_count: 1,
+        index_entries_count: 1,
+      });
+
+      await expect(
+        installRemoteCatalogBundle(db, entry, "https://example.test/catalog.json", {
+          fetchImpl,
+          signal: controller.signal,
+          onUpdate: (message) => {
+            if (!aborted && message.includes("[records.jsonl]") && message.includes("bytes read:")) {
+              aborted = true;
+              controller.abort(new Error("Cancel during records"));
+            }
+          },
+        }),
+      ).rejects.toThrow("Cancel during records");
+
+      const active = await getActiveBundleMeta(db);
+      expect(active?.storage_scope_id).toBe(oldScope);
+      expect((await getInstalledBundleMeta(db, "maninka_fr_v1"))?.expected_content_sha256).toBe("sha256:old");
+      expect(await getBundleInstallSession(db)).toBeUndefined();
+      expect(await recoverInterruptedBundleInstall(db)).toBeUndefined();
+      expect((await searchQuery(db, oldScope, "hello")).ir_ids).toEqual([`${oldScope}-rec`]);
+      expect((await searchQuery(db, newScope, "hello")).ir_ids).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("cancels during search index import and cleans staged state", async () => {
+    const oldScope = "maninka_fr_v1::sha256:old";
+    const newScope = "maninka_fr_v1::sha256:new";
+    const recordsText = makeJsonl(
+      Array.from({ length: 3 }, (_, index) => ({
+        ir_id: `new-rec-${index + 1}`,
+        ir_kind: "lexicon_entry",
+        source_id: `new-src-${index + 1}`,
+        norm_version: "norm_v1",
+        preferred_form: `new-${index + 1}`,
+        variant_forms: [`new-${index + 1}`],
+        search_keys: { casefold: [`hello-${index + 1}`] },
+        display: { headword_latin: `new-${index + 1}` },
+      })),
+    );
+    const indexText = makeJsonl(
+      Array.from({ length: 4 }, (_, index) => ({
+        key_type: "casefold",
+        key: `hello-${index + 1}`,
+        ir_ids: [`new-rec-${Math.min(index + 1, 3)}`],
+      })),
+    );
+    const manifestText = JSON.stringify({
+      manifest_schema_version: "bundle_manifest_v1",
+      bundle_id: "maninka_fr_v1",
+      bundle_type: "full",
+      bundle_format: "directory",
+      compression: "none",
+      record_schema_id: "normalized_v1",
+      record_schema_version: "1",
+      rule_versions: { normalization: "norm_v1" },
+      sources: { included: ["src"], excluded: [] },
+      reconciliation_action: "REPLACE_ALL",
+      update_mode: "REPLACE_ALL",
+      files: [
+        {
+          path: "records.jsonl",
+          byte_length: new TextEncoder().encode(recordsText).byteLength,
+          sha256: "sha256:records",
+        },
+        {
+          path: "search_index.jsonl",
+          byte_length: new TextEncoder().encode(indexText).byteLength,
+          sha256: "sha256:index",
+        },
+      ],
+      content_sha256: "sha256:new",
+    });
+    const entry: BundleCatalogEntryV1 = {
+      bundle_id: "maninka_fr_v1",
+      name: "French ↔ Maninka",
+      size_bytes: new TextEncoder().encode(recordsText).byteLength + new TextEncoder().encode(indexText).byteLength,
+      url_base: "./bundles/maninka_fr_v1/",
+      content_sha256: "sha256:new",
+    };
+    const controller = new AbortController();
+    let aborted = false;
+
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/bundle.manifest.json")) {
+        return makeResponseWithUrl(manifestText, "application/json", url);
+      }
+      if (url.endsWith("/records.jsonl")) {
+        return makeResponseWithUrl(recordsText, "application/json", url, true);
+      }
+      if (url.endsWith("/search_index.jsonl")) {
+        return makeResponseWithUrl(indexText, "application/json", url, true);
+      }
+      throw init?.signal?.reason ?? new Error("unexpected fetch");
+    };
+
+    const db = await openSiralexDb();
+    try {
+      await seedInstalledBundleScope(db, oldScope, "old-entry", "hello");
+      await setActiveBundleMeta(db, {
+        bundle_id: "maninka_fr_v1",
+        storage_scope_id: oldScope,
+        manifest_schema_version: "bundle_manifest_v1",
+        record_schema_id: "normalized_v1",
+        record_schema_version: "1",
+        normalization_ruleset: "norm_v1",
+        update_mode: "REPLACE_ALL",
+        reconciliation_action: "REPLACE_ALL",
+        expected_content_sha256: "sha256:old",
+        imported_at_iso: "2026-03-11T00:00:00Z",
+        records_count: 1,
+        index_entries_count: 1,
+      });
+
+      await expect(
+        installRemoteCatalogBundle(db, entry, "https://example.test/catalog.json", {
+          fetchImpl,
+          signal: controller.signal,
+          onUpdate: (message) => {
+            if (!aborted && message.includes("[search_index.jsonl]") && message.includes("bytes read:")) {
+              aborted = true;
+              controller.abort(new Error("Cancel during index"));
+            }
+          },
+        }),
+      ).rejects.toThrow("Cancel during index");
+
+      const active = await getActiveBundleMeta(db);
+      expect(active?.storage_scope_id).toBe(oldScope);
+      expect((await getInstalledBundleMeta(db, "maninka_fr_v1"))?.expected_content_sha256).toBe("sha256:old");
+      expect(await getBundleInstallSession(db)).toBeUndefined();
+      expect(await recoverInterruptedBundleInstall(db)).toBeUndefined();
+      expect((await searchQuery(db, oldScope, "hello")).ir_ids).toEqual([`${oldScope}-rec`]);
+      expect((await searchQuery(db, newScope, "hello-1")).ir_ids).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -108,6 +108,90 @@ input[type="text"]::placeholder {
   white-space: pre-wrap;
 }
 
+.catalog-empty {
+  color: var(--muted);
+  font-size: 13px;
+  padding: 12px;
+  border: 1px dashed color-mix(in oklab, var(--panel) 65%, white 15%);
+  border-radius: 10px;
+}
+
+.catalog-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.catalog-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid color-mix(in oklab, var(--panel) 72%, white 18%);
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--panel) 90%, black 10%);
+}
+
+.catalog-item-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.catalog-item-title {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.catalog-item-subtitle {
+  font-size: 12px;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+.catalog-item-meta {
+  font-size: 12px;
+  color: color-mix(in oklab, var(--text) 90%, var(--muted) 10%);
+}
+
+.catalog-item-note {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.catalog-badge {
+  flex-shrink: 0;
+  font-size: 11px;
+  border-radius: 999px;
+  padding: 3px 8px;
+  border: 1px solid transparent;
+}
+
+.catalog-badge-active {
+  color: #bfdbfe;
+  background: color-mix(in oklab, var(--accent) 18%, transparent 82%);
+  border-color: color-mix(in oklab, var(--accent) 35%, transparent 65%);
+}
+
+.catalog-badge-installed {
+  color: #d1fae5;
+  background: color-mix(in oklab, #10b981 18%, transparent 82%);
+  border-color: color-mix(in oklab, #10b981 35%, transparent 65%);
+}
+
+.catalog-badge-update {
+  color: #fde68a;
+  background: color-mix(in oklab, #f59e0b 18%, transparent 82%);
+  border-color: color-mix(in oklab, #f59e0b 35%, transparent 65%);
+}
+
+.catalog-badge-available {
+  color: var(--muted);
+  background: color-mix(in oklab, var(--panel) 88%, white 12%);
+  border-color: color-mix(in oklab, var(--panel) 65%, white 20%);
+}
+
 a {
   color: var(--accent);
 }


### PR DESCRIPTION
Add catalog discovery, remote bundle streaming, and staged install recovery so dictionaries can be installed safely without manual file picking.

## What does this PR change?

- 

## Why?

- 

## Checklist (required)

- [ ] I kept this PR narrowly scoped.
- [ ] If I changed language data / meaning, I explained the impact and any uncertainty.
- [ ] If this touches third-party sources, I preserved attribution and did not add content without permission.
- [ ] If this changes normalization/transliteration behavior, I added examples (inputs → outputs) in the PR description.

## Screenshots / notes (if applicable)

- 

