### PR TITLE
feat(search): add directional bundle-aware lookup

### DIFF
--- a/api/search_index/build_index.py
+++ b/api/search_index/build_index.py
@@ -2,7 +2,8 @@
 Search index builder: Normalized JSONL → Inverted search index JSONL.
 
 Reads normalized records and materializes a flat inverted index where
-each line maps a (key_type, key) pair to a sorted list of ir_ids.
+each line maps a directional (key_type, key) pair to a sorted list of
+ir_ids.
 
 This module never mutates normalized records. Output is a separate JSONL
 file that can be used for offline search resolution.
@@ -10,7 +11,7 @@ file that can be used for offline search resolution.
 Output schema (one JSON object per line):
 {
   "key": "dɔbɛn",
-  "key_type": "diacritics_insensitive",
+  "key_type": "tgt_diacritics_insensitive",
   "ir_ids": ["964909ef6912ff64", ...]
 }
 
@@ -25,6 +26,20 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+SOURCE_DIRECTION_PREFIX = "src"
+TARGET_DIRECTION_PREFIX = "tgt"
+
+INDEX_MAPPING_KIND = "index_mapping"
+LEXICON_ENTRY_KIND = "lexicon_entry"
+
+
+def directional_key_type(ir_kind: str, key_type: str) -> str | None:
+    if ir_kind == INDEX_MAPPING_KIND:
+        return f"{SOURCE_DIRECTION_PREFIX}_{key_type}"
+    if ir_kind == LEXICON_ENTRY_KIND:
+        return f"{TARGET_DIRECTION_PREFIX}_{key_type}"
+    return None
+
 
 def build_inverted_index(
     normalized_records: list[dict[str, Any]],
@@ -37,22 +52,31 @@ def build_inverted_index(
             "ir_id" and "search_keys" fields.
 
     Returns:
-        dict mapping (key_type, key) → set of ir_ids
+        dict mapping (directional key_type, key) → set of ir_ids
     """
     index: dict[tuple[str, str], set[str]] = defaultdict(set)
 
     for record in normalized_records:
         ir_id = record.get("ir_id", "")
+        ir_kind = record.get("ir_kind", "")
         search_keys = record.get("search_keys", {})
 
         if not ir_id:
             logger.warning("Normalized record missing ir_id, skipping")
             continue
 
+        if not isinstance(search_keys, dict):
+            logger.warning("Normalized record %s has invalid search_keys, skipping", ir_id)
+            continue
+
         for key_type, keys in search_keys.items():
+            directional_type = directional_key_type(ir_kind, key_type)
+            if directional_type is None:
+                logger.warning("Normalized record %s has unsupported ir_kind=%r, skipping", ir_id, ir_kind)
+                break
             for key in keys:
                 if key:  # skip empty keys
-                    index[(key_type, key)].add(ir_id)
+                    index[(directional_type, key)].add(ir_id)
 
     return index
 

--- a/api/search_index/tests/test_search_index.py
+++ b/api/search_index/tests/test_search_index.py
@@ -105,27 +105,42 @@ class TestBuildInvertedIndex:
             search_keys={"casefold": ["hello"]},
         )]
         index = build_inverted_index(records)
-        assert ("casefold", "hello") in index
-        assert index[("casefold", "hello")] == {"aaa"}
+        assert ("tgt_casefold", "hello") in index
+        assert index[("tgt_casefold", "hello")] == {"aaa"}
 
     def test_single_record_multiple_key_types(self):
         records = [FIXTURE_LEXICON_DOBEN]
         index = build_inverted_index(records)
 
-        assert ("casefold", "dɔ́bɛ̀n") in index
-        assert ("diacritics_insensitive", "dɔbɛn") in index
-        assert ("diacritics_insensitive", "doben") in index
-        assert FIXTURE_LEXICON_DOBEN["ir_id"] in index[("casefold", "dɔ́bɛ̀n")]
+        assert ("tgt_casefold", "dɔ́bɛ̀n") in index
+        assert ("tgt_diacritics_insensitive", "dɔbɛn") in index
+        assert ("tgt_diacritics_insensitive", "doben") in index
+        assert FIXTURE_LEXICON_DOBEN["ir_id"] in index[("tgt_casefold", "dɔ́bɛ̀n")]
 
     def test_multiple_records_key_collision(self):
         """Two records sharing the same diacritics_insensitive key."""
         records = [FIXTURE_LEXICON_DOBEN, FIXTURE_LEXICON_DOBEN_ALT]
         index = build_inverted_index(records)
 
-        doben_ids = index[("diacritics_insensitive", "doben")]
+        doben_ids = index[("tgt_diacritics_insensitive", "doben")]
         assert FIXTURE_LEXICON_DOBEN["ir_id"] in doben_ids
         assert FIXTURE_LEXICON_DOBEN_ALT["ir_id"] in doben_ids
         assert len(doben_ids) == 2
+
+    def test_bilingual_bundle_emits_source_and_target_key_families(self):
+        records = [FIXTURE_LEXICON_DOBEN, FIXTURE_INDEX_ABANDONNER]
+        index = build_inverted_index(records)
+
+        assert ("tgt_casefold", "dɔ́bɛ̀n") in index
+        assert ("src_casefold", "abandonner") in index
+        assert index[("src_casefold", "abandonner")] == {"eeee5555ffff6666"}
+        assert index[("tgt_casefold", "dɔ́bɛ̀n")] == {"aaaa1111bbbb2222"}
+
+    def test_mono_direction_bundle_only_emits_present_direction(self):
+        index = build_inverted_index([FIXTURE_INDEX_ABANDONNER])
+
+        assert ("src_casefold", "abandonner") in index
+        assert all(not key_type.startswith("tgt_") for key_type, _ in index.keys())
 
     def test_empty_records_list(self):
         index = build_inverted_index([])
@@ -143,14 +158,23 @@ class TestBuildInvertedIndex:
             search_keys={"casefold": ["", "hello"]},
         )]
         index = build_inverted_index(records)
-        assert ("casefold", "") not in index
-        assert ("casefold", "hello") in index
+        assert ("tgt_casefold", "") not in index
+        assert ("tgt_casefold", "hello") in index
 
     def test_missing_ir_id_skipped(self):
         """Records without ir_id should be skipped."""
         records = [{"search_keys": {"casefold": ["hello"]}}]
         index = build_inverted_index(records)
         assert len(index) == 0
+
+    def test_unsupported_ir_kind_is_skipped(self):
+        records = [make_normalized_record(
+            ir_id="aaa",
+            ir_kind="unsupported_kind",
+            search_keys={"casefold": ["hello"]},
+        )]
+        index = build_inverted_index(records)
+        assert index == {}
 
 
 # ===========================================================================
@@ -162,23 +186,23 @@ class TestSerializeIndex:
 
     def test_sorted_by_key_type_then_key(self):
         index = {
-            ("nospace", "b"): {"id1"},
-            ("casefold", "a"): {"id2"},
-            ("casefold", "b"): {"id3"},
-            ("diacritics_insensitive", "a"): {"id4"},
+            ("tgt_nospace", "b"): {"id1"},
+            ("src_casefold", "a"): {"id2"},
+            ("tgt_casefold", "b"): {"id3"},
+            ("src_diacritics_insensitive", "a"): {"id4"},
         }
         entries = serialize_index(index)
 
         key_type_key_pairs = [(e["key_type"], e["key"]) for e in entries]
         assert key_type_key_pairs == [
-            ("casefold", "a"),
-            ("casefold", "b"),
-            ("diacritics_insensitive", "a"),
-            ("nospace", "b"),
+            ("src_casefold", "a"),
+            ("src_diacritics_insensitive", "a"),
+            ("tgt_casefold", "b"),
+            ("tgt_nospace", "b"),
         ]
 
     def test_ir_ids_sorted(self):
-        index = {("casefold", "x"): {"ccc", "aaa", "bbb"}}
+        index = {("tgt_casefold", "x"): {"ccc", "aaa", "bbb"}}
         entries = serialize_index(index)
         assert entries[0]["ir_ids"] == ["aaa", "bbb", "ccc"]
 
@@ -187,13 +211,13 @@ class TestSerializeIndex:
         assert entries == []
 
     def test_entry_schema(self):
-        index = {("casefold", "hello"): {"id1"}}
+        index = {("src_casefold", "hello"): {"id1"}}
         entries = serialize_index(index)
         assert len(entries) == 1
         entry = entries[0]
         assert set(entry.keys()) == {"key", "key_type", "ir_ids"}
         assert entry["key"] == "hello"
-        assert entry["key_type"] == "casefold"
+        assert entry["key_type"] == "src_casefold"
         assert entry["ir_ids"] == ["id1"]
 
 
@@ -261,12 +285,38 @@ class TestProcessNormalizedFile:
             # Find the "doben" diacritics_insensitive entry
             doben_entries = [
                 e for e in entries
-                if e["key"] == "doben" and e["key_type"] == "diacritics_insensitive"
+                if e["key"] == "doben" and e["key_type"] == "tgt_diacritics_insensitive"
             ]
             assert len(doben_entries) == 1
             assert len(doben_entries[0]["ir_ids"]) == 2
             assert FIXTURE_LEXICON_DOBEN["ir_id"] in doben_entries[0]["ir_ids"]
             assert FIXTURE_LEXICON_DOBEN_ALT["ir_id"] in doben_entries[0]["ir_ids"]
+
+    def test_asymmetric_bundle_keeps_source_and_target_keys_isolated(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "normalized.jsonl"
+            output_path = Path(tmpdir) / "index.jsonl"
+
+            self._write_jsonl(input_path, [
+                FIXTURE_LEXICON_DOBEN_ALT,
+                FIXTURE_INDEX_ABANDONNER,
+            ])
+
+            process_normalized_file(input_path, output_path)
+            entries = self._read_jsonl(output_path)
+
+            assert any(
+                e["key_type"] == "src_casefold" and e["key"] == "abandonner"
+                for e in entries
+            )
+            assert any(
+                e["key_type"] == "tgt_casefold" and e["key"] == "dòbèn"
+                for e in entries
+            )
+            assert not any(
+                e["key_type"] == "src_casefold" and e["key"] == "dòbèn"
+                for e in entries
+            )
 
     def test_determinism(self):
         """Running twice on the same input produces identical output bytes."""
@@ -330,10 +380,10 @@ class TestProcessNormalizedFile:
             stats = process_normalized_file(input_path, output_path)
 
             # FIXTURE_LEXICON_DOBEN has keys in all 4 types
-            assert "casefold" in stats["unique_keys_by_type"]
-            assert "diacritics_insensitive" in stats["unique_keys_by_type"]
-            assert "punct_stripped" in stats["unique_keys_by_type"]
-            assert "nospace" in stats["unique_keys_by_type"]
+            assert "tgt_casefold" in stats["unique_keys_by_type"]
+            assert "tgt_diacritics_insensitive" in stats["unique_keys_by_type"]
+            assert "tgt_punct_stripped" in stats["unique_keys_by_type"]
+            assert "tgt_nospace" in stats["unique_keys_by_type"]
 
     def test_output_lines_are_valid_json(self):
         """Every output line must be valid JSON with the right schema."""

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,6 +8,7 @@ Guiding constraints:
 - **Offline-first**: the dictionary must remain usable without connectivity.
 - **Provenance-first**: store provenance at **entry**, **sense**, and **example** levels.
 - **Community trust**: no hallucinated language; uncertainty is surfaced.
+- **Product language scope is explicit**: shipped dictionary surfaces are limited to **French/English ↔ Maninka**. If upstream source data contains other languages (for example Russian glosses/examples), those may remain in frozen source artifacts for provenance/history, but they are **out of scope for the product** and should not expand the runtime dictionary language set.
 
 ---
 
@@ -383,6 +384,41 @@ UI labels should be generated from manifest metadata instead of hardcoded string
 DoD:
 - Search labels, toggle text, placeholders, and entry-render labels are derived from the active bundle metadata.
 - Frontend runtime code no longer embeds a specific target language in its direction model.
+- Runtime search semantics enforce the selected direction instead of treating the toggle as display-only state.
+
+#### Phase 4.2.5 — Directional search semantics
+
+This mini-phase makes the direction toggle real at query time without changing the normalized record schema.
+
+Bundle contract:
+
+- `search_index.jsonl` stores directional `key_type` values rather than a separate `direction` field
+- source-side keys use the `src_` prefix
+- target-side keys use the `tgt_` prefix
+- the exactness ladder stays the same within each direction family:
+  - `src_casefold` → `src_diacritics_insensitive` → `src_punct_stripped` → `src_nospace`
+  - `tgt_casefold` → `tgt_diacritics_insensitive` → `tgt_punct_stripped` → `tgt_nospace`
+
+Runtime rule:
+
+- `source_to_target` searches only `src_*` keys
+- `target_to_source` searches only `tgt_*` keys
+- search still stops at the first matching exactness level and preserves stored `ir_ids[]` order
+
+Current bundle-generation mapping:
+
+- `index_mapping` records emit `src_*` keys from `fields_raw.source_term`
+- `lexicon_entry` records emit `tgt_*` keys from headword/variant normalization
+
+**Recommended future: bundle-level capability flag**
+
+Right now the runtime tries the directional ladder first and falls back to the legacy (undirected) ladder only when the directional ladder returns zero results. That can create subtle ranking distortions later (e.g. directional bundle has a weak match, legacy fallback would have had a strong match → confusing ordering). To avoid hybrid logic:
+
+- Add a manifest flag, e.g. `search_index_directional: true`.
+- **If directional bundle** (flag true): never fallback; use only the directional ladder.
+- **If legacy bundle** (flag absent or false): always use the legacy ladder only; do not try directional keys.
+
+Then each bundle type has a single, predictable code path and no mixed ranking.
 
 ### Phase 3.3 — Installed bundle registry
 
@@ -436,6 +472,41 @@ These are valid future directions, but they should not be framed as Phase 3 prer
 - speculative performance work not justified by observed bundle size or device behavior
 
 Those belong in a later scaling/performance phase once real multi-bundle usage and device measurements justify them.
+
+### Phase 5+ problem — Search Index Granularity Improvement
+
+This is a real search-quality problem, but it is **not a Phase 4.3 blocker**. Phase 4.3 should continue on the current directional contract and runtime semantics.
+
+Current limitation:
+
+- the search index is built from whole normalized source terms and target headword/variant forms
+- it does **not** break gloss-like source strings into smaller atomic searchable units
+- this can reduce match quality for:
+  - multiword phrases
+  - punctuation-heavy glosses
+  - diacritics variants when users search partial or simplified forms
+
+Scope for the later improvement:
+
+- break gloss into tokens
+- index atomic searchable units
+- possibly add n-gram / phrase indexing
+- improve matching for:
+  - multiword phrases
+  - punctuation-heavy glosses
+  - diacritics variants
+
+Guardrails:
+
+- do not replace the current bundle/search contract prematurely
+- do not block directional indexing rollout on this work
+- base any tokenization or phrase-indexing rules on observed bundle behavior and real query needs, not speculative over-design
+
+DoD (future):
+
+- the project has a documented, versioned indexing strategy for atomic units vs whole-string keys
+- real-bundle tests show better retrieval for phrase-heavy and punctuation-heavy source entries without regressing deterministic bundle generation
+- any new indexing mode is explicit in bundle metadata/versioning rather than silently changing search semantics
 
 ### Phase 2 memory constraint (lock-in before IndexedDB)
 

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1153,7 +1153,7 @@ async function runSearch(query: string) {
     }
     const activeStorageScopeId = getBundleStorageScopeId(activeBundleMeta);
 
-    const result = await searchQuery(db, activeStorageScopeId, query);
+    const result = await searchQuery(db, activeStorageScopeId, searchDirection, query);
     if (seq !== searchSeq) return;
 
     if (result.ir_ids.length === 0) {

--- a/web/src/phase3_bundle_runtime.test.ts
+++ b/web/src/phase3_bundle_runtime.test.ts
@@ -120,7 +120,7 @@ describe("Phase 3 bundle-aware runtime", () => {
       await importSearchIndexJsonl(
         db,
         makeJsonlFile("search_index.jsonl", [
-          { key_type: "casefold", key: "hello", ir_ids: ["rec-a"] },
+          { key_type: "tgt_casefold", key: "hello", ir_ids: ["rec-a"] },
         ]),
         { bundleId: bundleA, batchSize: 10 },
       );
@@ -162,7 +162,7 @@ describe("Phase 3 bundle-aware runtime", () => {
       await importSearchIndexJsonl(
         db,
         makeJsonlFile("search_index.jsonl", [
-          { key_type: "casefold", key: "hello", ir_ids: ["rec-b"] },
+          { key_type: "tgt_casefold", key: "hello", ir_ids: ["rec-b"] },
         ]),
         { bundleId: bundleB, batchSize: 10 },
       );
@@ -191,7 +191,7 @@ describe("Phase 3 bundle-aware runtime", () => {
       let active = await getActiveBundleMeta(db);
       expect(active?.bundle_id).toBe(bundleB);
 
-      let result = await searchQuery(db, bundleB, "hello");
+      let result = await searchQuery(db, bundleB, "target_to_source", "hello");
       expect(result.ir_ids).toEqual(["rec-b"]);
       let records = await resolveRecords(db, bundleB, result.ir_ids);
       expect(records.map((record) => record.ir_id)).toEqual(["rec-b"]);
@@ -200,7 +200,7 @@ describe("Phase 3 bundle-aware runtime", () => {
       active = await getActiveBundleMeta(db);
       expect(active?.bundle_id).toBe(bundleA);
 
-      result = await searchQuery(db, bundleA, "hello");
+      result = await searchQuery(db, bundleA, "target_to_source", "hello");
       expect(result.ir_ids).toEqual(["rec-a"]);
       records = await resolveRecords(db, bundleA, result.ir_ids);
       expect(records.map((record) => record.ir_id)).toEqual(["rec-a"]);
@@ -234,7 +234,7 @@ describe("Phase 3 bundle-aware runtime", () => {
       await importSearchIndexJsonl(
         db,
         makeJsonlFile("search_index.jsonl", [
-          { key_type: "casefold", key: "hello", ir_ids: ["rec-a"] },
+          { key_type: "tgt_casefold", key: "hello", ir_ids: ["rec-a"] },
         ]),
         { bundleId: bundleA, batchSize: 10 },
       );
@@ -268,7 +268,7 @@ describe("Phase 3 bundle-aware runtime", () => {
       await importSearchIndexJsonl(
         db,
         makeJsonlFile("search_index.jsonl", [
-          { key_type: "casefold", key: "hello", ir_ids: ["rec-b"] },
+          { key_type: "tgt_casefold", key: "hello", ir_ids: ["rec-b"] },
         ]),
         { bundleId: bundleB, batchSize: 10 },
       );
@@ -294,7 +294,7 @@ describe("Phase 3 bundle-aware runtime", () => {
       const active = await getActiveBundleMeta(db);
       expect(active?.bundle_id).toBe("bundle_full_a_aaaaaaaa");
 
-      const result = await searchQuery(db, "bundle_full_a_aaaaaaaa", "hello");
+      const result = await searchQuery(db, "bundle_full_a_aaaaaaaa", "target_to_source", "hello");
       expect(result.ir_ids).toEqual(["rec-a"]);
       const records = await resolveRecords(db, "bundle_full_a_aaaaaaaa", result.ir_ids);
       expect(records.map((record) => record.ir_id)).toEqual(["rec-a"]);
@@ -325,7 +325,7 @@ describe("Phase 3 bundle-aware runtime", () => {
       await importSearchIndexJsonl(
         db,
         makeJsonlFile("search_index.jsonl", [
-          { key_type: "casefold", key: "hello", ir_ids: ["rec-staged"] },
+          { key_type: "tgt_casefold", key: "hello", ir_ids: ["rec-staged"] },
         ]),
         { bundleId: "bundle_a::sha256:new", batchSize: 10 },
       );
@@ -341,12 +341,12 @@ describe("Phase 3 bundle-aware runtime", () => {
         imported_at_iso: "2026-03-10T00:00:00Z",
       });
 
-      let result = await searchQuery(db, "bundle_a::sha256:new", "hello");
+      let result = await searchQuery(db, "bundle_a::sha256:new", "target_to_source", "hello");
       expect(result.ir_ids).toEqual(["rec-staged"]);
 
       await deleteBundleData(db, "bundle_a");
 
-      result = await searchQuery(db, "bundle_a::sha256:new", "hello");
+      result = await searchQuery(db, "bundle_a::sha256:new", "target_to_source", "hello");
       expect(result.ir_ids).toEqual([]);
     } finally {
       db.close();
@@ -383,8 +383,139 @@ describe("Phase 3 bundle-aware runtime", () => {
       const message = await recoverInterruptedBundleInstall(db);
       expect(message).toContain("Recovered committed install");
 
-      const result = await searchQuery(db, "bundle_a", "old");
+      const result = await searchQuery(db, "bundle_a", "target_to_source", "old");
       expect(result.ir_ids).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("filters search to the selected direction within a bilingual bundle", async () => {
+    const db = await openSiralexDb();
+    try {
+      const bundleId = "bundle_full_bilingual_aaaaaaaa";
+
+      await importRecordsJsonl(
+        db,
+        makeJsonlFile("records.jsonl", [
+          {
+            ir_id: "rec-source",
+            ir_kind: "index_mapping",
+            source_id: "src_index",
+            norm_version: "norm_v1",
+            preferred_form: "abandonner",
+            variant_forms: ["abandonner"],
+            search_keys: { casefold: ["abandonner"] },
+            display: {
+              source_term: "abandonner",
+              source_lang: "fr",
+              target_entries: [{ lexicon_url: "../lexicon/b.htm", anchor: "e1", display_text: "bàn" }],
+            },
+          },
+          {
+            ir_id: "rec-target",
+            ir_kind: "lexicon_entry",
+            source_id: "src_lexicon",
+            norm_version: "norm_v1",
+            preferred_form: "bàn",
+            variant_forms: ["bàn"],
+            search_keys: { casefold: ["bàn"] },
+            display: { headword_latin: "bàn" },
+          },
+        ]),
+        { bundleId, batchSize: 10 },
+      );
+      await importSearchIndexJsonl(
+        db,
+        makeJsonlFile("search_index.jsonl", [
+          { key_type: "src_casefold", key: "abandonner", ir_ids: ["rec-source"] },
+          { key_type: "tgt_casefold", key: "bàn", ir_ids: ["rec-target"] },
+        ]),
+        { bundleId, batchSize: 10 },
+      );
+
+      expect((await searchQuery(db, bundleId, "source_to_target", "abandonner")).ir_ids).toEqual(["rec-source"]);
+      expect((await searchQuery(db, bundleId, "target_to_source", "bàn")).ir_ids).toEqual(["rec-target"]);
+      expect((await searchQuery(db, bundleId, "source_to_target", "bàn")).ir_ids).toEqual([]);
+      expect((await searchQuery(db, bundleId, "target_to_source", "abandonner")).ir_ids).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("fails closed when a bundle only contains one direction family", async () => {
+    const db = await openSiralexDb();
+    try {
+      const bundleId = "bundle_full_target_only_aaaaaaaa";
+
+      await importRecordsJsonl(
+        db,
+        makeJsonlFile("records.jsonl", [
+          {
+            ir_id: "rec-target",
+            ir_kind: "lexicon_entry",
+            source_id: "src_lexicon",
+            norm_version: "norm_v1",
+            preferred_form: "bàn",
+            variant_forms: ["bàn"],
+            search_keys: { casefold: ["bàn"] },
+            display: { headword_latin: "bàn" },
+          },
+        ]),
+        { bundleId, batchSize: 10 },
+      );
+      await importSearchIndexJsonl(
+        db,
+        makeJsonlFile("search_index.jsonl", [
+          { key_type: "tgt_casefold", key: "bàn", ir_ids: ["rec-target"] },
+        ]),
+        { bundleId, batchSize: 10 },
+      );
+
+      expect((await searchQuery(db, bundleId, "target_to_source", "bàn")).ir_ids).toEqual(["rec-target"]);
+      expect((await searchQuery(db, bundleId, "source_to_target", "bàn")).ir_ids).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("falls back to undirected key types for bundles built before Phase 4.2.5", async () => {
+    const db = await openSiralexDb();
+    try {
+      const bundleId = "bundle_legacy_undirected_keys";
+
+      await importRecordsJsonl(
+        db,
+        makeJsonlFile("records.jsonl", [
+          {
+            ir_id: "rec-ouverture",
+            ir_kind: "index_mapping",
+            source_id: "src_malipense",
+            norm_version: "norm_v1",
+            preferred_form: "ouverture",
+            variant_forms: ["ouverture"],
+            search_keys: { casefold: ["ouverture"], diacritics_insensitive: ["ouverture"] },
+            display: {
+              source_term: "ouverture",
+              source_lang: "fr",
+              target_entries: [{ lexicon_url: "../lexicon/d.htm", anchor: "e2204", display_text: "dá" }],
+            },
+          },
+        ]),
+        { bundleId, batchSize: 10 },
+      );
+      // Legacy format: undirected key_type (no src_ / tgt_ prefix)
+      await importSearchIndexJsonl(
+        db,
+        makeJsonlFile("search_index.jsonl", [
+          { key_type: "casefold", key: "ouverture", ir_ids: ["rec-ouverture"] },
+          { key_type: "diacritics_insensitive", key: "ouverture", ir_ids: ["rec-ouverture"] },
+        ]),
+        { bundleId, batchSize: 10 },
+      );
+
+      expect((await searchQuery(db, bundleId, "source_to_target", "ouverture")).ir_ids).toEqual(["rec-ouverture"]);
+      expect((await searchQuery(db, bundleId, "target_to_source", "ouverture")).ir_ids).toEqual(["rec-ouverture"]);
     } finally {
       db.close();
     }

--- a/web/src/phase4_remote_install.test.ts
+++ b/web/src/phase4_remote_install.test.ts
@@ -102,7 +102,7 @@ async function seedInstalledBundleScope(
   );
   await importSearchIndexJsonl(
     db,
-    new Blob([makeJsonl([{ key_type: "casefold", key: lookupKey, ir_ids: [`${storageScopeId}-rec`] }])]),
+    new Blob([makeJsonl([{ key_type: "tgt_casefold", key: lookupKey, ir_ids: [`${storageScopeId}-rec`] }])]),
     { bundleId: storageScopeId, batchSize: 10 },
   );
 }
@@ -129,7 +129,7 @@ describe("Phase 4.2 remote install", () => {
         display: { headword_latin: "bonjour" },
       },
     ]);
-    const indexText = makeJsonl([{ key_type: "casefold", key: "hello", ir_ids: ["rec-1"] }]);
+    const indexText = makeJsonl([{ key_type: "tgt_casefold", key: "hello", ir_ids: ["rec-1"] }]);
     const manifestText = JSON.stringify({
       manifest_schema_version: "bundle_manifest_v1",
       bundle_id: "maninka_fr_v1",
@@ -202,7 +202,7 @@ describe("Phase 4.2 remote install", () => {
       const installed = await getInstalledBundleMeta(db, "maninka_fr_v1");
       expect(installed?.expected_content_sha256).toBe("sha256:bundle");
 
-      const resultIds = await searchQuery(db, active!.storage_scope_id!, "hello");
+      const resultIds = await searchQuery(db, active!.storage_scope_id!, "target_to_source", "hello");
       expect(resultIds.ir_ids).toEqual(["rec-1"]);
       const records = await resolveRecords(db, active!.storage_scope_id!, resultIds.ir_ids);
       expect(records.map((record) => record.ir_id)).toEqual(["rec-1"]);
@@ -318,7 +318,7 @@ describe("Phase 4.2 remote install", () => {
     );
     const indexText = makeJsonl(
       Array.from({ length: 4 }, (_, index) => ({
-        key_type: "casefold",
+        key_type: "tgt_casefold",
         key: `hello-${index + 1}`,
         ir_ids: [`new-rec-${index + 1}`],
       })),
@@ -409,8 +409,8 @@ describe("Phase 4.2 remote install", () => {
       expect((await getInstalledBundleMeta(db, "maninka_fr_v1"))?.expected_content_sha256).toBe("sha256:old");
       expect(await getBundleInstallSession(db)).toBeUndefined();
       expect(await recoverInterruptedBundleInstall(db)).toBeUndefined();
-      expect((await searchQuery(db, oldScope, "hello")).ir_ids).toEqual([`${oldScope}-rec`]);
-      expect((await searchQuery(db, newScope, "hello")).ir_ids).toEqual([]);
+      expect((await searchQuery(db, oldScope, "target_to_source", "hello")).ir_ids).toEqual([`${oldScope}-rec`]);
+      expect((await searchQuery(db, newScope, "target_to_source", "hello")).ir_ids).toEqual([]);
     } finally {
       db.close();
     }
@@ -433,7 +433,7 @@ describe("Phase 4.2 remote install", () => {
     );
     const indexText = makeJsonl(
       Array.from({ length: 4 }, (_, index) => ({
-        key_type: "casefold",
+        key_type: "tgt_casefold",
         key: `hello-${index + 1}`,
         ir_ids: [`new-rec-${Math.min(index + 1, 3)}`],
       })),
@@ -524,8 +524,8 @@ describe("Phase 4.2 remote install", () => {
       expect((await getInstalledBundleMeta(db, "maninka_fr_v1"))?.expected_content_sha256).toBe("sha256:old");
       expect(await getBundleInstallSession(db)).toBeUndefined();
       expect(await recoverInterruptedBundleInstall(db)).toBeUndefined();
-      expect((await searchQuery(db, oldScope, "hello")).ir_ids).toEqual([`${oldScope}-rec`]);
-      expect((await searchQuery(db, newScope, "hello-1")).ir_ids).toEqual([]);
+      expect((await searchQuery(db, oldScope, "target_to_source", "hello")).ir_ids).toEqual([`${oldScope}-rec`]);
+      expect((await searchQuery(db, newScope, "target_to_source", "hello-1")).ir_ids).toEqual([]);
     } finally {
       db.close();
     }

--- a/web/src/search/search_query.ts
+++ b/web/src/search/search_query.ts
@@ -1,7 +1,8 @@
 /**
  * Phase 2.0.3b — Query execution (retrieval correctness).
  *
- * Single entry point: searchQuery(db, activeBundleId, query) → ordered ir_id[].
+ * Single entry point: searchQuery(db, activeBundleId, direction, query) →
+ * ordered ir_id[].
  *
  * Uses computeSearchKeys from norm_v1.ts (the same normalization path as the
  * import pipeline) to derive 4 search keys from the raw query string.
@@ -15,6 +16,7 @@
 
 import { STORE_SEARCH_INDEX } from "../idb/siralex_db";
 import { computeSearchKeys, type SearchKeys } from "../norm/norm_v1";
+import type { SearchDirection } from "../bundle_labels";
 
 const KEY_TYPE_ORDER: (keyof SearchKeys)[] = [
   "casefold",
@@ -22,6 +24,10 @@ const KEY_TYPE_ORDER: (keyof SearchKeys)[] = [
   "punct_stripped",
   "nospace",
 ];
+
+function toDirectionalKeyType(direction: SearchDirection, keyType: keyof SearchKeys): string {
+  return `${direction === "source_to_target" ? "src" : "tgt"}_${keyType}`;
+}
 
 export type SearchResult = {
   ir_ids: string[];
@@ -40,12 +46,26 @@ function idbGet<T>(store: IDBObjectStore, key: IDBValidKey): Promise<T | undefin
 /**
  * Search the IndexedDB search_index store using the exactness ladder.
  *
+ * Phase 4.2.5: Prefer directional key types (src_* / tgt_*) so that the
+ * selected search direction only hits keys for that side. For bundles built
+ * before directional indexing (legacy bundles with undirected key_type like
+ * "casefold"), falls back to the undirected ladder so search still works.
+ *
+ * Future improvement (recommended): Use a bundle-level capability flag
+ * (e.g. manifest "search_index_directional": true) so that:
+ * - Directional bundle → NEVER fallback; use only the directional ladder.
+ * - Legacy bundle → ALWAYS use the legacy (undirected) ladder only.
+ * This avoids hybrid "try directional then fallback" logic, which can cause
+ * subtle ranking distortions (e.g. weak directional match vs strong legacy
+ * match producing confusing result order).
+ *
  * @returns Ordered ir_id list from the first matching level, or empty if
  *          no level matches. The result preserves the stored ir_ids[] order.
  */
 export async function searchQuery(
   db: IDBDatabase,
   activeBundleId: string,
+  direction: SearchDirection,
   query: string,
 ): Promise<SearchResult> {
   const trimmed = query.trim();
@@ -58,6 +78,25 @@ export async function searchQuery(
   const tx = db.transaction(STORE_SEARCH_INDEX, "readonly");
   const store = tx.objectStore(STORE_SEARCH_INDEX);
 
+  // 1) Directional ladder (bundles built with Phase 4.2.5+ index)
+  for (const keyType of KEY_TYPE_ORDER) {
+    const normalizedKeys = keys[keyType];
+    if (normalizedKeys.length === 0) continue;
+    const directionalKeyType = toDirectionalKeyType(direction, keyType);
+
+    for (const normalizedKey of normalizedKeys) {
+      const entry = await idbGet<{ ir_ids: string[] }>(store, [activeBundleId, directionalKeyType, normalizedKey]);
+      if (entry && Array.isArray(entry.ir_ids) && entry.ir_ids.length > 0) {
+        return {
+          ir_ids: entry.ir_ids,
+          matched_key_type: keyType,
+          matched_key: normalizedKey,
+        };
+      }
+    }
+  }
+
+  // 2) Legacy fallback: undirected key types (bundles built before Phase 4.2.5)
   for (const keyType of KEY_TYPE_ORDER) {
     const normalizedKeys = keys[keyType];
     if (normalizedKeys.length === 0) continue;


### PR DESCRIPTION
Implement directional search index semantics across the index builder, web runtime, and tests so the language toggle controls actual lookup behavior. Document future search-index granularity work and clarify product language scope without committing local validation bundles.

## What does this PR change?

- 

## Why?

- 

## Checklist (required)

- [ ] I kept this PR narrowly scoped.
- [ ] If I changed language data / meaning, I explained the impact and any uncertainty.
- [ ] If this touches third-party sources, I preserved attribution and did not add content without permission.
- [ ] If this changes normalization/transliteration behavior, I added examples (inputs → outputs) in the PR description.

## Screenshots / notes (if applicable)

- 

