### PR TITLE
feat(web): add bundle update state handling

### DIFF
--- a/web/src/bundle_catalog.test.ts
+++ b/web/src/bundle_catalog.test.ts
@@ -258,5 +258,16 @@ describe("Phase 4.1 update semantics", () => {
       installed: true,
       contentMatches: false,
     });
+
+    expect(
+      compareCatalogEntryToInstalled(entry, {
+        bundle_id: "bambara_fr_v1",
+        expected_content_sha256: "sha256:new",
+      }),
+    ).toMatchObject({
+      state: "not_installed",
+      installed: false,
+      contentMatches: false,
+    });
   });
 });

--- a/web/src/install/bundle_install.ts
+++ b/web/src/install/bundle_install.ts
@@ -14,6 +14,7 @@ import {
   deleteBundleScopeData,
   getBundleStorageScopeId,
   getInstalledBundleMeta,
+  putInstalledBundleMeta,
   recoverInterruptedBundleInstall,
   setActiveBundleMeta,
   setBundleInstallSession,
@@ -50,6 +51,7 @@ export type InstallRemoteBundleOptions = {
   timeoutMs?: number;
   onUpdate?: (message: string) => void;
   storageEstimate?: () => Promise<{ usage?: number; quota?: number }>;
+  activateOnCommit?: boolean;
 };
 
 export type InstallBundleMetadata = {
@@ -205,6 +207,7 @@ export async function installBundleIntoDb(
   onUpdate: (message: string) => void,
   signal?: AbortSignal,
   metadata?: InstallBundleMetadata,
+  activateOnCommit = true,
 ): Promise<InstallBundleResult> {
   const recovered = await recoverInterruptedBundleInstall(db);
   if (recovered) {
@@ -274,10 +277,12 @@ export async function installBundleIntoDb(
     });
     indexCount = idxRes.entriesWritten;
 
-    await setActiveBundleMeta(
-      db,
-      buildInstalledBundleMeta(manifest, nextStorageScopeId, recordsCount, indexCount, metadata),
-    );
+    const installedMeta = buildInstalledBundleMeta(manifest, nextStorageScopeId, recordsCount, indexCount, metadata);
+    if (activateOnCommit) {
+      await setActiveBundleMeta(db, installedMeta);
+    } else {
+      await putInstalledBundleMeta(db, installedMeta);
+    }
     await setBundleInstallSession(db, {
       bundle_id: manifest.bundle_id,
       storage_scope_id: nextStorageScopeId,
@@ -354,13 +359,15 @@ export async function installRemoteCatalogBundle(
 
     const installed = await getInstalledBundleMeta(db, entry.bundle_id);
     if (installed?.expected_content_sha256 === entry.content_sha256) {
-      await setActiveBundleMeta(
-        db,
-        {
-          ...installed,
-          imported_at_iso: installed.imported_at_iso,
-        },
-      );
+      const installedMeta = {
+        ...installed,
+        imported_at_iso: installed.imported_at_iso,
+      };
+      if (options.activateOnCommit ?? true) {
+        await setActiveBundleMeta(db, installedMeta);
+      } else {
+        await putInstalledBundleMeta(db, installedMeta);
+      }
       return {
         manifest,
         result: {
@@ -418,6 +425,7 @@ export async function installRemoteCatalogBundle(
         version: entry.version,
         storageBytes: entry.size_bytes,
       },
+      options.activateOnCommit ?? true,
     );
 
     return { manifest, result };

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -268,6 +268,26 @@ function getKnownBundlePayloadBytes(bundles: ActiveBundleMeta[]): number | undef
   return known.reduce((sum, value) => sum + value, 0);
 }
 
+function getLoadedCatalogEntry(bundleId: string): BundleCatalogEntryV1 | undefined {
+  return loadedCatalogBundles.find((entry) => entry.bundle_id === bundleId);
+}
+
+function getCatalogEntryRuntimeState(entry: BundleCatalogEntryV1): {
+  installed?: ActiveBundleMeta;
+  isActive: boolean;
+  comparison: ReturnType<typeof compareCatalogEntryToInstalled>;
+  activateOnCommit: boolean;
+} {
+  const installed = installedBundles.find((bundle) => bundle.bundle_id === entry.bundle_id);
+  const isActive = currentActiveBundle?.bundle_id === entry.bundle_id;
+  return {
+    installed,
+    isActive,
+    comparison: compareCatalogEntryToInstalled(entry, installed),
+    activateOnCommit: !installed || isActive,
+  };
+}
+
 function renderInstalledBundleManager() {
   installedBundleList.innerHTML = "";
 
@@ -311,11 +331,30 @@ function renderInstalledBundleManager() {
     bundleId.textContent = bundle.bundle_id;
     titleBlock.append(title, bundleId);
 
-    const badge = document.createElement("span");
     const isActive = currentActiveBundle?.bundle_id === bundle.bundle_id;
-    badge.className = `catalog-badge ${isActive ? "catalog-badge-active" : "catalog-badge-installed"}`;
-    badge.textContent = isActive ? "Active" : "Installed";
-    header.append(titleBlock, badge);
+    const catalogEntry = getLoadedCatalogEntry(bundle.bundle_id);
+    const catalogState = catalogEntry ? getCatalogEntryRuntimeState(catalogEntry) : undefined;
+    const updateAvailable = catalogState?.comparison.state === "update_available";
+    const badges = document.createElement("div");
+    badges.className = "row";
+    if (isActive) {
+      const activeBadge = document.createElement("span");
+      activeBadge.className = "catalog-badge catalog-badge-active";
+      activeBadge.textContent = "Active";
+      badges.appendChild(activeBadge);
+    }
+    if (updateAvailable) {
+      const updateBadge = document.createElement("span");
+      updateBadge.className = "catalog-badge catalog-badge-update";
+      updateBadge.textContent = "Update available";
+      badges.appendChild(updateBadge);
+    } else if (!isActive) {
+      const installedBadge = document.createElement("span");
+      installedBadge.className = "catalog-badge catalog-badge-installed";
+      installedBadge.textContent = "Installed";
+      badges.appendChild(installedBadge);
+    }
+    header.append(titleBlock, badges);
 
     const meta = document.createElement("div");
     meta.className = "catalog-item-meta";
@@ -335,9 +374,27 @@ function renderInstalledBundleManager() {
       `Installed: ${formatInstalledAt(bundle.imported_at_iso)}\n` +
       `Storage scope: ${getBundleStorageScopeId(bundle)}\n` +
       `Normalization: ${bundle.normalization_ruleset} | Schema: ${bundle.record_schema_id}@${bundle.record_schema_version}`;
+    if (updateAvailable && catalogEntry) {
+      note.textContent +=
+        `\nInstalled hash: ${bundle.expected_content_sha256 ?? "unknown"}` +
+        `\nCatalog hash: ${catalogEntry.content_sha256}`;
+    }
 
     const actions = document.createElement("div");
     actions.className = "row";
+
+    if (updateAvailable && catalogEntry) {
+      const updateBtn = document.createElement("button");
+      updateBtn.className = "btn";
+      updateBtn.textContent = "Update";
+      updateBtn.disabled = busy || !loadedCatalogUrl;
+      updateBtn.addEventListener("click", () => {
+        void withSingleWriterLock(`update bundle ${bundle.bundle_id}`, async () => {
+          await installCatalogEntry(catalogEntry, catalogState?.activateOnCommit ?? isActive);
+        });
+      });
+      actions.appendChild(updateBtn);
+    }
 
     const useBtn = document.createElement("button");
     useBtn.className = "btn";
@@ -495,9 +552,7 @@ function getCatalogPresentationState(entry: BundleCatalogEntryV1): {
   badgeLabel: string;
   note?: string;
 } {
-  const installed = installedBundles.find((bundle) => bundle.bundle_id === entry.bundle_id);
-  const comparison = compareCatalogEntryToInstalled(entry, installed);
-  const isActive = currentActiveBundle?.bundle_id === entry.bundle_id;
+  const { comparison, isActive } = getCatalogEntryRuntimeState(entry);
 
   if (comparison.state === "update_available") {
     return {
@@ -522,9 +577,8 @@ function getCatalogPresentationState(entry: BundleCatalogEntryV1): {
 }
 
 function getCatalogActionLabel(entry: BundleCatalogEntryV1): string {
-  const installed = installedBundles.find((bundle) => bundle.bundle_id === entry.bundle_id);
-  const comparison = compareCatalogEntryToInstalled(entry, installed);
-  if (currentActiveBundle?.bundle_id === entry.bundle_id && comparison.state === "installed_current") {
+  const { comparison, isActive } = getCatalogEntryRuntimeState(entry);
+  if (isActive && comparison.state === "installed_current") {
     return "Active";
   }
   if (comparison.state === "update_available") return "Update";
@@ -608,8 +662,9 @@ function renderCatalogList() {
     actionBtn.textContent = getCatalogActionLabel(entry);
     actionBtn.disabled = busy || !loadedCatalogUrl || actionBtn.textContent === "Active";
     actionBtn.addEventListener("click", () => {
+      const { activateOnCommit } = getCatalogEntryRuntimeState(entry);
       void withSingleWriterLock(`install catalog bundle ${entry.bundle_id}`, async () => {
-        await installCatalogEntry(entry);
+        await installCatalogEntry(entry, activateOnCommit);
       });
     });
     actions.appendChild(actionBtn);
@@ -837,9 +892,11 @@ async function quickImportBundle(fileList: FileList) {
     return;
   }
 
+  let activateOnCommit = true;
   try {
     const existingDb = await openSiralexDb();
     const installed = await getInstalledBundleMeta(existingDb, mfst.bundle_id);
+    const activeBundleId = await getActiveBundleId(existingDb);
     if (installed) {
       if (installed.expected_content_sha256 === mfst.content_sha256) {
         await setActiveBundleId(existingDb, mfst.bundle_id);
@@ -848,10 +905,12 @@ async function quickImportBundle(fileList: FileList) {
         await refreshDbStatus();
         return;
       }
+      activateOnCommit = activeBundleId === mfst.bundle_id;
       importProgress.textContent =
         `Updating installed bundle ${mfst.bundle_id}.\n` +
         `Existing hash: ${installed.expected_content_sha256 ?? "unknown"}\n` +
-        `New hash: ${mfst.content_sha256}\n`;
+        `New hash: ${mfst.content_sha256}\n` +
+        `${activateOnCommit ? "Updated bundle will remain active." : "Current active bundle will remain unchanged."}\n`;
     }
     existingDb.close();
   } catch {
@@ -878,6 +937,7 @@ async function quickImportBundle(fileList: FileList) {
         displayName: getBundleDisplayName(mfst.bundle_id, buildLanguageMetaFromManifest(mfst)),
         storageBytes: getManifestPayloadBytes(mfst),
       },
+      activateOnCommit,
     );
     importProgress.textContent =
       `Install complete: ${mfst.bundle_id}\n` +
@@ -964,7 +1024,7 @@ async function restoreCachedCatalogFromDb() {
   }
 }
 
-async function installCatalogEntry(entry: BundleCatalogEntryV1) {
+async function installCatalogEntry(entry: BundleCatalogEntryV1, activateOnCommit = true) {
   if (!loadedCatalogUrl) {
     importProgress.style.display = "";
     importProgress.textContent = "No catalog source URL is available for this entry.\n";
@@ -994,6 +1054,7 @@ async function installCatalogEntry(entry: BundleCatalogEntryV1) {
   const db = await openSiralexDb();
   try {
     const { manifest, result } = await installRemoteCatalogBundle(db, entry, loadedCatalogUrl, {
+      activateOnCommit,
       signal: controller.signal,
       onUpdate: (message) => {
         importProgress.textContent = message;
@@ -1091,9 +1152,11 @@ importBundleBtn.addEventListener("click", () => {
     const ix = indexFile.files?.[0];
     if (!mfst || !rf || !ix) return;
 
+    let activateOnCommit = true;
     try {
       const existingDb = await openSiralexDb();
       const installed = await getInstalledBundleMeta(existingDb, mfst.bundle_id);
+      const activeBundleId = await getActiveBundleId(existingDb);
       if (installed) {
         if (installed.expected_content_sha256 === mfst.content_sha256) {
           await setActiveBundleId(existingDb, mfst.bundle_id);
@@ -1101,10 +1164,12 @@ importBundleBtn.addEventListener("click", () => {
           dbOut.textContent = `Bundle already installed. Marked active: ${mfst.bundle_id}\n`;
           return;
         }
+        activateOnCommit = activeBundleId === mfst.bundle_id;
         dbOut.textContent =
           `Updating installed bundle ${mfst.bundle_id}.\n` +
           `Existing hash: ${installed.expected_content_sha256 ?? "unknown"}\n` +
-          `New hash: ${mfst.content_sha256}\n`;
+          `New hash: ${mfst.content_sha256}\n` +
+          `${activateOnCommit ? "Updated bundle will remain active." : "Current active bundle will remain unchanged."}\n`;
       }
       existingDb.close();
     } catch {
@@ -1129,6 +1194,7 @@ importBundleBtn.addEventListener("click", () => {
           displayName: getBundleDisplayName(mfst.bundle_id, buildLanguageMetaFromManifest(mfst)),
           storageBytes: getManifestPayloadBytes(mfst),
         },
+        activateOnCommit,
       );
       dbOut.textContent =
         `Install COMPLETE\n` +

--- a/web/src/phase4_remote_install.test.ts
+++ b/web/src/phase4_remote_install.test.ts
@@ -10,6 +10,7 @@ import {
   getInstalledBundleMeta,
   openSiralexDb,
   recoverInterruptedBundleInstall,
+  setActiveBundleId,
   setActiveBundleMeta,
 } from "./idb/siralex_db";
 import { importRecordsJsonl } from "./import/import_records";
@@ -209,6 +210,216 @@ describe("Phase 4.2 remote install", () => {
       expect(resultIds.ir_ids).toEqual(["rec-1"]);
       const records = await resolveRecords(db, active!.storage_scope_id!, resultIds.ir_ids);
       expect(records.map((record) => record.ir_id)).toEqual(["rec-1"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps an updated active bundle active and serves the new scope", async () => {
+    const oldScope = "maninka_fr_v1::sha256:old";
+    const newScope = "maninka_fr_v1::sha256:new";
+    const recordsText = makeJsonl([
+      {
+        ir_id: "rec-new",
+        ir_kind: "lexicon_entry",
+        source_id: "src_new",
+        norm_version: "norm_v1",
+        preferred_form: "updated-entry",
+        variant_forms: ["updated-entry"],
+        search_keys: { casefold: ["hello"] },
+        display: { headword_latin: "updated-entry" },
+      },
+    ]);
+    const indexText = makeJsonl([{ key_type: "tgt_casefold", key: "hello", ir_ids: ["rec-new"] }]);
+    const manifestText = JSON.stringify({
+      manifest_schema_version: "bundle_manifest_v1",
+      bundle_id: "maninka_fr_v1",
+      bundle_type: "full",
+      bundle_format: "directory",
+      compression: "none",
+      record_schema_id: "normalized_v1",
+      record_schema_version: "1",
+      rule_versions: { normalization: "norm_v1" },
+      sources: { included: ["src"], excluded: [] },
+      reconciliation_action: "REPLACE_ALL",
+      update_mode: "REPLACE_ALL",
+      files: [
+        {
+          path: "records.jsonl",
+          byte_length: new TextEncoder().encode(recordsText).byteLength,
+          sha256: "sha256:records",
+        },
+        {
+          path: "search_index.jsonl",
+          byte_length: new TextEncoder().encode(indexText).byteLength,
+          sha256: "sha256:index",
+        },
+      ],
+      content_sha256: "sha256:new",
+    });
+    const entry: BundleCatalogEntryV1 = {
+      bundle_id: "maninka_fr_v1",
+      name: "French ↔ Maninka",
+      size_bytes: new TextEncoder().encode(recordsText).byteLength + new TextEncoder().encode(indexText).byteLength,
+      url_base: "./bundles/maninka_fr_v1/",
+      content_sha256: "sha256:new",
+    };
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = String(input);
+      if (url.endsWith("/bundle.manifest.json")) return makeResponse(manifestText, "application/json");
+      if (url.endsWith("/records.jsonl")) return makeResponse(recordsText, "application/json");
+      if (url.endsWith("/search_index.jsonl")) return makeResponse(indexText, "application/json");
+      return new Response("not found", { status: 404, statusText: "Not Found" });
+    };
+
+    const db = await openSiralexDb();
+    try {
+      await seedInstalledBundleScope(db, oldScope, "old-entry", "hello");
+      await setActiveBundleMeta(db, {
+        bundle_id: "maninka_fr_v1",
+        storage_scope_id: oldScope,
+        manifest_schema_version: "bundle_manifest_v1",
+        record_schema_id: "normalized_v1",
+        record_schema_version: "1",
+        normalization_ruleset: "norm_v1",
+        update_mode: "REPLACE_ALL",
+        reconciliation_action: "REPLACE_ALL",
+        expected_content_sha256: "sha256:old",
+        imported_at_iso: "2026-03-11T00:00:00Z",
+        records_count: 1,
+        index_entries_count: 1,
+      });
+
+      await installRemoteCatalogBundle(db, entry, "https://example.test/catalog.json", {
+        fetchImpl,
+        activateOnCommit: true,
+      });
+
+      const active = await getActiveBundleMeta(db);
+      expect(active?.bundle_id).toBe("maninka_fr_v1");
+      expect(active?.storage_scope_id).toBe(newScope);
+      expect((await getInstalledBundleMeta(db, "maninka_fr_v1"))?.storage_scope_id).toBe(newScope);
+
+      const resultIds = await searchQuery(db, newScope, "target_to_source", "hello");
+      expect(resultIds.ir_ids).toEqual(["rec-new"]);
+      const records = await resolveRecords(db, newScope, resultIds.ir_ids);
+      expect(records.map((record) => record.preferred_form)).toEqual(["updated-entry"]);
+      expect((await searchQuery(db, oldScope, "target_to_source", "hello")).ir_ids).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("updates a non-active bundle without changing the current active bundle", async () => {
+    const activeScope = "bundle_a::sha256:active";
+    const oldScope = "bundle_b::sha256:old";
+    const newScope = "bundle_b::sha256:new";
+    const recordsText = makeJsonl([
+      {
+        ir_id: "bundle-b-new",
+        ir_kind: "lexicon_entry",
+        source_id: "bundle-b-src",
+        norm_version: "norm_v1",
+        preferred_form: "bundle-b-updated",
+        variant_forms: ["bundle-b-updated"],
+        search_keys: { casefold: ["bundle-b"] },
+        display: { headword_latin: "bundle-b-updated" },
+      },
+    ]);
+    const indexText = makeJsonl([{ key_type: "tgt_casefold", key: "bundle-b", ir_ids: ["bundle-b-new"] }]);
+    const manifestText = JSON.stringify({
+      manifest_schema_version: "bundle_manifest_v1",
+      bundle_id: "bundle_b",
+      bundle_type: "full",
+      bundle_format: "directory",
+      compression: "none",
+      record_schema_id: "normalized_v1",
+      record_schema_version: "1",
+      rule_versions: { normalization: "norm_v1" },
+      sources: { included: ["src"], excluded: [] },
+      reconciliation_action: "REPLACE_ALL",
+      update_mode: "REPLACE_ALL",
+      files: [
+        {
+          path: "records.jsonl",
+          byte_length: new TextEncoder().encode(recordsText).byteLength,
+          sha256: "sha256:records",
+        },
+        {
+          path: "search_index.jsonl",
+          byte_length: new TextEncoder().encode(indexText).byteLength,
+          sha256: "sha256:index",
+        },
+      ],
+      content_sha256: "sha256:new",
+    });
+    const entry: BundleCatalogEntryV1 = {
+      bundle_id: "bundle_b",
+      name: "Bundle B",
+      size_bytes: new TextEncoder().encode(recordsText).byteLength + new TextEncoder().encode(indexText).byteLength,
+      url_base: "./bundles/bundle_b/",
+      content_sha256: "sha256:new",
+    };
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = String(input);
+      if (url.endsWith("/bundle.manifest.json")) return makeResponse(manifestText, "application/json");
+      if (url.endsWith("/records.jsonl")) return makeResponse(recordsText, "application/json");
+      if (url.endsWith("/search_index.jsonl")) return makeResponse(indexText, "application/json");
+      return new Response("not found", { status: 404, statusText: "Not Found" });
+    };
+
+    const db = await openSiralexDb();
+    try {
+      await seedInstalledBundleScope(db, activeScope, "active-entry", "bundle-a");
+      await seedInstalledBundleScope(db, oldScope, "old-bundle-b", "bundle-b");
+      await setActiveBundleMeta(db, {
+        bundle_id: "bundle_a",
+        storage_scope_id: activeScope,
+        manifest_schema_version: "bundle_manifest_v1",
+        record_schema_id: "normalized_v1",
+        record_schema_version: "1",
+        normalization_ruleset: "norm_v1",
+        update_mode: "REPLACE_ALL",
+        reconciliation_action: "REPLACE_ALL",
+        expected_content_sha256: "sha256:active",
+        imported_at_iso: "2026-03-11T00:00:00Z",
+        records_count: 1,
+        index_entries_count: 1,
+      });
+      await setActiveBundleMeta(db, {
+        bundle_id: "bundle_b",
+        storage_scope_id: oldScope,
+        manifest_schema_version: "bundle_manifest_v1",
+        record_schema_id: "normalized_v1",
+        record_schema_version: "1",
+        normalization_ruleset: "norm_v1",
+        update_mode: "REPLACE_ALL",
+        reconciliation_action: "REPLACE_ALL",
+        expected_content_sha256: "sha256:old",
+        imported_at_iso: "2026-03-11T00:00:00Z",
+        records_count: 1,
+        index_entries_count: 1,
+      });
+      await setActiveBundleId(db, "bundle_a");
+
+      await installRemoteCatalogBundle(db, entry, "https://example.test/catalog.json", {
+        fetchImpl,
+        activateOnCommit: false,
+      });
+
+      const active = await getActiveBundleMeta(db);
+      expect(active?.bundle_id).toBe("bundle_a");
+      expect(active?.storage_scope_id).toBe(activeScope);
+
+      const installedB = await getInstalledBundleMeta(db, "bundle_b");
+      expect(installedB?.storage_scope_id).toBe(newScope);
+      expect(installedB?.expected_content_sha256).toBe("sha256:new");
+
+      const activeIds = await searchQuery(db, activeScope, "target_to_source", "bundle-a");
+      expect(activeIds.ir_ids).toEqual([`${activeScope}-rec`]);
+      const updatedIds = await searchQuery(db, newScope, "target_to_source", "bundle-b");
+      expect(updatedIds.ir_ids).toEqual(["bundle-b-new"]);
+      expect((await searchQuery(db, oldScope, "target_to_source", "bundle-b")).ir_ids).toEqual([]);
     } finally {
       db.close();
     }


### PR DESCRIPTION
Keep non-active bundle updates from stealing focus while surfacing update state consistently in both bundle management views.

## What does this PR change?

- 

## Why?

- 

## Checklist (required)

- [ ] I kept this PR narrowly scoped.
- [ ] If I changed language data / meaning, I explained the impact and any uncertainty.
- [ ] If this touches third-party sources, I preserved attribution and did not add content without permission.
- [ ] If this changes normalization/transliteration behavior, I added examples (inputs → outputs) in the PR description.

## Screenshots / notes (if applicable)

- 

