### PR TITLE
feat(search): add norm_v2 indexing and resilient bundle imports

### DIFF
--- a/api/bundle_builder/build_bundle.py
+++ b/api/bundle_builder/build_bundle.py
@@ -153,6 +153,39 @@ def _count_records_by_kind(normalized_path: Path) -> dict[str, int]:
     return counts
 
 
+def _detect_normalization_ruleset(normalized_path: Path) -> str:
+    """
+    Detect the normalization ruleset used by the normalized records.
+
+    All normalized records in a bundle must share the same norm_version.
+    """
+    detected: str | None = None
+
+    with open(normalized_path, "r", encoding="utf-8") as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            norm_version = record.get("norm_version")
+            if not isinstance(norm_version, str) or not norm_version:
+                raise ValueError(
+                    f"Normalized record missing norm_version at {normalized_path}:{line_num}"
+                )
+            if detected is None:
+                detected = norm_version
+            elif norm_version != detected:
+                raise ValueError(
+                    "Normalized records mix multiple norm_version values: "
+                    f"{detected!r} and {norm_version!r}"
+                )
+
+    if detected is None:
+        raise ValueError(f"No normalized records found in {normalized_path}")
+
+    return detected
+
+
 # ---------------------------------------------------------------------------
 # Bundle builder
 # ---------------------------------------------------------------------------
@@ -205,6 +238,7 @@ def build_bundle(
 
     # Count records by ir_kind for informational metadata
     record_counts = _count_records_by_kind(normalized_path)
+    normalization_ruleset = _detect_normalization_ruleset(normalized_path)
 
     # Date string for bundle ID
     date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
@@ -254,7 +288,7 @@ def build_bundle(
         "record_schema_id": "normalized_v1",
         "record_schema_version": "1",
         "rule_versions": {
-            "normalization": "norm_v1",
+            "normalization": normalization_ruleset,
         },
         "sources": {
             "included": sorted(sources_included),

--- a/api/bundle_builder/tests/test_bundle_builder.py
+++ b/api/bundle_builder/tests/test_bundle_builder.py
@@ -48,6 +48,43 @@ SAMPLE_NORMALIZED_RECORDS = [
     },
 ]
 
+SAMPLE_NORMALIZED_RECORDS_V2 = [
+    {
+        "ir_id": "ffff1111eeee2222",
+        "ir_kind": "index_mapping",
+        "source_id": "src_malipense",
+        "norm_version": "norm_v2",
+        "preferred_form": "a) bon travail! (une salutation), b) merci! (pour un travail)",
+        "variant_forms": [
+            "a) bon travail! (une salutation), b) merci! (pour un travail)",
+            "bon travail",
+            "merci",
+        ],
+        "search_keys": {
+            "casefold": [
+                "a) bon travail! (une salutation), b) merci! (pour un travail)",
+                "bon travail",
+                "merci",
+            ],
+            "diacritics_insensitive": [
+                "a) bon travail! (une salutation), b) merci! (pour un travail)",
+                "bon travail",
+                "merci",
+            ],
+            "punct_stripped": [
+                "a bon travail une salutation b merci pour un travail",
+                "bon travail",
+                "merci",
+            ],
+            "nospace": [
+                "a)bontravail!(unesalutation),b)merci!(pouruntravail)",
+                "bontravail",
+                "merci",
+            ],
+        },
+    },
+]
+
 SAMPLE_INDEX_ENTRIES = [
     {
         "key": "test",
@@ -69,6 +106,15 @@ def bundle_inputs(tmp_path):
     normalized = tmp_path / "normalized.jsonl"
     search_index = tmp_path / "search_index.jsonl"
     write_jsonl(normalized, SAMPLE_NORMALIZED_RECORDS)
+    write_jsonl(search_index, SAMPLE_INDEX_ENTRIES)
+    return normalized, search_index
+
+
+@pytest.fixture
+def bundle_inputs_v2(tmp_path):
+    normalized = tmp_path / "normalized_v2.jsonl"
+    search_index = tmp_path / "search_index_v2.jsonl"
+    write_jsonl(normalized, SAMPLE_NORMALIZED_RECORDS_V2)
     write_jsonl(search_index, SAMPLE_INDEX_ENTRIES)
     return normalized, search_index
 
@@ -228,6 +274,15 @@ class TestBuildBundle:
         manifest = result["manifest"]
 
         assert manifest["rule_versions"]["normalization"] == "norm_v1"
+
+    def test_rule_versions_follow_normalized_records(self, bundle_inputs_v2, tmp_path):
+        normalized, search_index = bundle_inputs_v2
+        output_dir = tmp_path / "bundles"
+
+        result = build_bundle(normalized, search_index, output_dir)
+        manifest = result["manifest"]
+
+        assert manifest["rule_versions"]["normalization"] == "norm_v2"
 
     def test_sources_included(self, bundle_inputs, tmp_path):
         normalized, search_index = bundle_inputs

--- a/api/normalizer/cli.py
+++ b/api/normalizer/cli.py
@@ -12,7 +12,7 @@ from pathlib import Path
 # Add shared to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "shared"))
 
-from normalization.norm_v1 import RULESET_ID
+from normalization.norm_v2 import RULESET_ID
 from .normalize import process_ir_files
 
 logger = logging.getLogger(__name__)

--- a/api/normalizer/normalize.py
+++ b/api/normalizer/normalize.py
@@ -12,7 +12,7 @@ Output schema (one JSON object per line):
   "ir_id": "...",
   "ir_kind": "lexicon_entry" | "index_mapping",
   "source_id": "...",
-  "norm_version": "norm_v1",
+  "norm_version": "<current ruleset>",
   "preferred_form": "...",
   "variant_forms": ["...", ...],
   "search_keys": {
@@ -34,9 +34,10 @@ from typing import Any, Iterator
 # Add shared to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "shared"))
 
-from normalization.norm_v1 import (
+from normalization.norm_v2 import (
     RULESET_ID,
     compute_search_keys,
+    extract_source_phrases,
     normalize_nfc,
 )
 
@@ -79,6 +80,7 @@ def normalize_lexicon_entry(ir_unit: dict[str, Any]) -> NormalizedRecord:
     record_locator = ir_unit.get("record_locator", {})
 
     headword = fields_raw.get("headword_latin", "")
+    headword_nko = fields_raw.get("headword_nko_provided", "")
     anchor_names = record_locator.get("anchor_names", [])
 
     # Preferred form is the source's own headword
@@ -94,6 +96,12 @@ def normalize_lexicon_entry(ir_unit: dict[str, Any]) -> NormalizedRecord:
             variant_forms.insert(0, preferred_form)
     else:
         variant_forms = [preferred_form] if preferred_form else []
+
+    # Add source-provided N'Ko headword as an additional searchable variant.
+    if headword_nko:
+        nko_nfc = normalize_nfc(headword_nko)
+        if not any(normalize_nfc(v) == nko_nfc for v in variant_forms):
+            variant_forms.append(headword_nko)
 
     # Compute search keys from all variant forms
     search_keys = compute_search_keys(variant_forms)
@@ -114,15 +122,16 @@ def normalize_index_mapping(ir_unit: dict[str, Any]) -> NormalizedRecord:
     Normalize an index_mapping IR unit.
 
     Preferred form: fields_raw.source_term (the French headword)
-    Variant forms: [source_term] (index mappings have no variant forms)
+    Variant forms: additive source phrases derived from fields_raw.source_term
+    while always preserving the full original source_term.
     """
     fields_raw = ir_unit.get("fields_raw", {})
 
     source_term = fields_raw.get("source_term", "")
 
-    # For index mappings, there's only one form
+    # For index mappings, preserve the original and add deterministic phrases.
     preferred_form = source_term
-    variant_forms = [source_term] if source_term else []
+    variant_forms = extract_source_phrases(source_term)
 
     # Compute search keys
     search_keys = compute_search_keys(variant_forms)

--- a/api/normalizer/tests/test_norm_v1_golden_fixtures.py
+++ b/api/normalizer/tests/test_norm_v1_golden_fixtures.py
@@ -262,7 +262,7 @@ class TestNormalizeLexiconEntry:
         }
         result = normalize_lexicon_entry(ir_unit)
         assert result.preferred_form == "dɔ́bɛ̀n"
-        assert result.norm_version == "norm_v1"
+        assert result.norm_version == "norm_v2"
 
     def test_variant_forms_include_preferred(self):
         ir_unit = {

--- a/api/normalizer/tests/test_norm_v2_features.py
+++ b/api/normalizer/tests/test_norm_v2_features.py
@@ -1,0 +1,125 @@
+"""
+Focused tests for norm_v2 additive search behavior.
+"""
+
+import sys
+from pathlib import Path
+
+
+# Add shared to path for imports.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "shared"))
+
+from normalization.norm_v2 import (  # noqa: E402
+    MAX_SOURCE_PHRASES,
+    RULESET_ID,
+    extract_source_phrases,
+)
+from normalizer.normalize import normalize_index_mapping, normalize_lexicon_entry  # noqa: E402
+
+
+def test_extract_source_phrases_keeps_original_and_adds_gloss_phrases():
+    source_term = (
+        "a) bon travail! (une salutation à celui qui est en train de travailler), "
+        "b) merci! (pour un travail)"
+    )
+
+    phrases = extract_source_phrases(source_term)
+
+    assert phrases[0] == source_term
+    assert "bon travail" in phrases
+    assert "merci" in phrases
+
+
+def test_extract_source_phrases_adds_parenthetical_free_variant():
+    source_term = "bon réveil! (lit : que tu sortes de la nuit!)"
+
+    phrases = extract_source_phrases(source_term)
+
+    assert source_term in phrases
+    assert "bon réveil" in phrases
+
+
+def test_extract_source_phrases_filters_stopword_only_segments():
+    source_term = "a) de la, b) bon travail"
+
+    phrases = extract_source_phrases(source_term)
+
+    assert source_term in phrases
+    assert "de la" not in phrases
+    assert "bon travail" in phrases
+
+
+def test_extract_source_phrases_preserves_multiword_phrase_without_word_tokens():
+    phrases = extract_source_phrases("bon travail")
+
+    assert phrases == ["bon travail"]
+
+
+def test_extract_source_phrases_caps_total_output():
+    source_term = ", ".join(f"{idx}. segment {idx} (note {idx})" for idx in range(1, 25))
+
+    phrases = extract_source_phrases(source_term)
+
+    assert phrases[0] == source_term
+    assert len(phrases) <= MAX_SOURCE_PHRASES
+
+
+def test_normalize_index_mapping_uses_extracted_source_phrases():
+    ir_unit = {
+        "ir_id": "idx-bon-travail",
+        "ir_kind": "index_mapping",
+        "source_id": "src_malipense",
+        "fields_raw": {
+            "source_term": (
+                "a) bon travail! (une salutation à celui qui est en train de travailler), "
+                "b) merci! (pour un travail)"
+            ),
+            "source_lang": "fr",
+        },
+    }
+
+    result = normalize_index_mapping(ir_unit)
+
+    assert result.norm_version == RULESET_ID
+    assert result.variant_forms[0] == ir_unit["fields_raw"]["source_term"]
+    assert "bon travail" in result.variant_forms
+    assert "merci" in result.variant_forms
+    assert "bon travail" in result.search_keys["casefold"]
+    assert "merci" in result.search_keys["casefold"]
+
+
+def test_normalize_index_mapping_adds_bon_reveil_variant():
+    ir_unit = {
+        "ir_id": "idx-bon-reveil",
+        "ir_kind": "index_mapping",
+        "source_id": "src_malipense",
+        "fields_raw": {
+            "source_term": "bon réveil! (lit : que tu sortes de la nuit!)",
+            "source_lang": "fr",
+        },
+    }
+
+    result = normalize_index_mapping(ir_unit)
+
+    assert result.norm_version == RULESET_ID
+    assert "bon réveil" in result.variant_forms
+    assert "bon réveil" in result.search_keys["casefold"]
+
+
+def test_normalize_lexicon_entry_adds_nko_headword_variant():
+    ir_unit = {
+        "ir_id": "lex-nko",
+        "ir_kind": "lexicon_entry",
+        "source_id": "src_malipense",
+        "record_locator": {"anchor_names": ["dàa"]},
+        "fields_raw": {
+            "headword_latin": "dàa",
+            "headword_nko_provided": "ߘߊ߰",
+        },
+    }
+
+    result = normalize_lexicon_entry(ir_unit)
+
+    assert result.norm_version == RULESET_ID
+    assert "ߘߊ߰" in result.variant_forms
+    assert "ߘߊ߰" in result.search_keys["casefold"]

--- a/api/search_index/tests/test_search_index.py
+++ b/api/search_index/tests/test_search_index.py
@@ -91,6 +91,39 @@ FIXTURE_INDEX_ABANDONNER = make_normalized_record(
     },
 )
 
+FIXTURE_INDEX_GLOSS_V2 = make_normalized_record(
+    ir_id="ffff7777aaaa8888",
+    ir_kind="index_mapping",
+    norm_version="norm_v2",
+    preferred_form="a) bon travail! (une salutation), b) merci! (pour un travail)",
+    variant_forms=[
+        "a) bon travail! (une salutation), b) merci! (pour un travail)",
+        "bon travail",
+        "merci",
+        "bon réveil",
+    ],
+    search_keys={
+        "casefold": ["bon travail", "merci", "bon réveil"],
+        "diacritics_insensitive": ["bon travail", "merci", "bon reveil"],
+        "punct_stripped": ["bon travail", "merci", "bon reveil"],
+        "nospace": ["bontravail", "merci", "bonreveil"],
+    },
+)
+
+FIXTURE_LEXICON_NKO_V2 = make_normalized_record(
+    ir_id="1111eeee2222ffff",
+    ir_kind="lexicon_entry",
+    norm_version="norm_v2",
+    preferred_form="dàa",
+    variant_forms=["dàa", "ߘߊ߰"],
+    search_keys={
+        "casefold": ["dàa", "ߘߊ߰"],
+        "diacritics_insensitive": ["daa", "ߘߊ"],
+        "punct_stripped": ["daa", "ߘߊ"],
+        "nospace": ["daa", "ߘߊ"],
+    },
+)
+
 
 # ===========================================================================
 # Category 1: Basic inverted index construction
@@ -135,6 +168,18 @@ class TestBuildInvertedIndex:
         assert ("src_casefold", "abandonner") in index
         assert index[("src_casefold", "abandonner")] == {"eeee5555ffff6666"}
         assert index[("tgt_casefold", "dɔ́bɛ̀n")] == {"aaaa1111bbbb2222"}
+
+    def test_v2_gloss_phrases_emit_directional_source_keys(self):
+        index = build_inverted_index([FIXTURE_INDEX_GLOSS_V2])
+
+        assert index[("src_casefold", "bon travail")] == {"ffff7777aaaa8888"}
+        assert index[("src_casefold", "merci")] == {"ffff7777aaaa8888"}
+        assert index[("src_casefold", "bon réveil")] == {"ffff7777aaaa8888"}
+
+    def test_v2_nko_variant_emits_directional_target_keys(self):
+        index = build_inverted_index([FIXTURE_LEXICON_NKO_V2])
+
+        assert index[("tgt_casefold", "ߘߊ߰")] == {"1111eeee2222ffff"}
 
     def test_mono_direction_bundle_only_emits_present_direction(self):
         index = build_inverted_index([FIXTURE_INDEX_ABANDONNER])

--- a/docs/BUILD_BUNDLE.md
+++ b/docs/BUILD_BUNDLE.md
@@ -32,7 +32,7 @@ Input artifact:
 Example path:
 
 ```text
-data/normalized/malipense_normalized_norm_v1.jsonl
+data/normalized/<dataset>_normalized_norm_vN.jsonl
 ```
 
 ## Step 2: Build the Search Index
@@ -73,6 +73,13 @@ Result:
 - `bundle.manifest.json`
 - `records.jsonl`
 - `search_index.jsonl`
+
+The bundle manifest's `rule_versions.normalization` value is derived from the
+normalized records' `norm_version`. This is how new rulesets such as
+`norm_v2` remain explicit in published bundles.
+
+For the formal `norm_v2` source-term phrase extraction contract, see
+`docs/GLOSS_DECOMPOSITION.md`.
 
 Expected shape:
 

--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -27,6 +27,20 @@ Normalization ruleset: `norm_v1` (pure Unicode transforms, no auxiliary data)
 
 **Immutability contract**: these artifacts will never be modified in place. Any future corrections or rule changes produce new versions (e.g., `malipense_lexicon_v4`, `norm_v2`).
 
+## Post-freeze normalization evolution
+
+The dataset freeze above remains authoritative for `norm_v1`.
+
+Search-quality improvements that change how variant forms are derived must ship
+as a new normalization ruleset and new derived artifacts, never by rewriting
+the frozen `norm_v1` outputs in place.
+
+Current planned successor:
+
+- `norm_v2`: keeps the full original `source_term`, adds deterministic
+  source-phrase extraction for `index_mapping`, and includes
+  `headword_nko_provided` in `lexicon_entry.variant_forms`
+
 ## How to cite
 
 If you use this dataset in research or other projects, please cite:

--- a/docs/GLOSS_DECOMPOSITION.md
+++ b/docs/GLOSS_DECOMPOSITION.md
@@ -1,0 +1,80 @@
+# Gloss Decomposition Contract
+
+This document defines the `norm_v2` source-term decomposition contract used for
+`index_mapping.fields_raw.source_term`.
+
+The goal is to improve real search quality without replacing or mutating the
+original stored string.
+
+## Scope
+
+This contract applies only to:
+
+- `index_mapping.fields_raw.source_term`
+
+It does not change:
+
+- `lexicon_entry` record structure
+- per-string search-key transforms
+- runtime search ladder semantics
+- storage or IndexedDB schema
+
+## Additive rule
+
+The original `source_term` MUST always be preserved as the first emitted
+variant.
+
+Any derived phrases are additive aliases. They never replace the original.
+
+## Decomposition pipeline
+
+`extract_source_phrases(source_term)` in `shared/normalization/norm_v2.py`
+follows this deterministic contract:
+
+1. Preserve the full original `source_term`.
+2. Split top-level enumerations such as `a)`, `b)`, `1.`, `2.`.
+3. Split each enumeration segment on top-level commas, semicolons, and slashes.
+4. For each resulting segment:
+   - keep the full segment
+   - if it ends with trailing parenthetical context, also emit a version
+     without that trailing parenthetical
+5. Strip leading and trailing punctuation for the cleaned variant only.
+6. Filter noise:
+   - minimum phrase length is `3`
+   - stopword-only phrases are discarded
+7. Deduplicate in first-seen order.
+
+## Quality constraints
+
+To keep index growth controlled, `norm_v2` uses these explicit limits:
+
+- no whitespace tokenization: multiword phrases stay intact
+- maximum top-level split segments processed from one `source_term`: `12`
+- maximum emitted phrases per `source_term` (including the original): `12`
+
+These limits are part of the versioned `norm_v2` ruleset behavior.
+
+## Intended outcomes
+
+Examples:
+
+- `a) bon travail! (une salutation ...), b) merci! (pour un travail)`
+  emits additive phrases including:
+  - the full original string
+  - `bon travail`
+  - `merci`
+
+- `bon réveil! (lit : que tu sortes de la nuit!)`
+  emits additive phrases including:
+  - the full original string
+  - `bon réveil`
+
+## Non-goals
+
+`norm_v2` does not:
+
+- generate single-word tokens from every phrase
+- rank derived phrases
+- infer synonyms
+- change frontend query semantics
+- mutate frozen `norm_v1` artifacts in place

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,4 +1,4 @@
-# Roadmap (Phase 0 → Phase 3)
+# Roadmap (Phase 0 → Phase 5)
 
 This roadmap documents the execution path to a usable, offline-first **French/English ↔ Maninka (Guinea)** dictionary and sentence analysis app with **Latin + N'Ko** as first-class scripts.
 
@@ -239,15 +239,17 @@ DoD:
 | 5b | Phase 2.0.3b — Query execution (retrieval correctness) | Primary focus | ✅ Complete |
 | 6 | Phase 2.0.4 — Results display + entry view (presentation correctness) | Primary focus | ✅ Complete |
 | 7 | Phase 2.0.5 — Offline PWA finalization (first-install → offline proof) | Primary focus | ✅ Complete |
-| 8 | Phase 3.1 — Manifest language metadata | Next platform step | Pending |
-| 9 | Phase 3.2 — Language-agnostic UI + direction semantics | Next platform step | Pending |
-| 10 | Phase 3.3 — Installed bundle registry | Next platform step | Pending |
-| 11 | Phase 3.4 — Multi-bundle support | Next platform step | Pending |
-| 12 | Phase 3.5 — Bundle selection + distribution | Next platform step | ✅ Complete |
-| 13 | Phase 1.5 (spec + backend) — Correction schema + pipeline | Parallel, light | Pending |
-| 14 | Branch C — Transliteration, morphology, linguistic inference | Only after users + data | Deferred |
+| 8 | Phase 3.1 — Manifest language metadata | Platform generalization | ✅ Complete |
+| 9 | Phase 3.2 — Language-agnostic UI + direction semantics | Platform generalization | ✅ Complete |
+| 10 | Phase 3.3 — Installed bundle registry | Platform generalization | ✅ Complete |
+| 11 | Phase 3.4 — Multi-bundle support | Platform generalization | ✅ Complete |
+| 12 | Phase 3.5 — Bundle selection + distribution | Platform generalization | ✅ Complete |
+| 13 | Phase 5 — Search/index quality improvement | Next primary focus | Pending |
+| 14 | Phase 1.5 (spec + backend) — Correction schema + pipeline | Parallel, light | Pending |
+| 15 | HTTPS deployment + iPhone offline validation | Release-readiness track | Pending |
+| 16 | Branch C — Transliteration, morphology, linguistic inference | Only after users + data | Deferred |
 
-Phase 2.0 (Branch A) has now served its purpose: it proved that the offline-first runtime, bundle ingestion, IndexedDB storage, search query execution, rendering, and PWA shell all work end-to-end for the first dictionary bundle. The next primary track is Phase 3: generalize the platform so language metadata, installed bundles, and active dictionary behavior are runtime concerns rather than hardcoded assumptions. Phase 1.5 backend work (Branch B) can still proceed in parallel as light, spec-level work. Branch C remains explicitly deferred until real usage data exists.
+Phase 2.0 (Branch A) and the originally planned Phase 3 platform work have now served their purpose: the runtime proves bundle ingestion, IndexedDB storage, query execution, rendering, offline shell behavior, manifest-driven language metadata, installed bundle registry, active bundle selection, multi-bundle isolation, and catalog-driven install/update flows. The roadmap was previously lagging behind this implementation reality. The next primary engineering track is therefore **Phase 5 — Search/index quality improvement**, not a return to earlier platform milestones. Phase 1.5 backend work can still proceed in parallel as light spec work, and HTTPS/iPhone validation remains an important release-readiness track. Branch C remains explicitly deferred until real usage data exists.
 
 The completed Phase 2.0 work followed clean layer separation:
 
@@ -330,7 +332,7 @@ DoD:
 
 ---
 
-## Phase 3 — Platform generalization + bundle metadata
+## Phase 3 — Platform generalization + bundle metadata ✅
 
 Goal: evolve SiraLex from a proven offline dictionary for the first language pair into a reusable platform that can host multiple language bundles without embedding language-specific logic in the app.
 
@@ -348,9 +350,11 @@ Goal: evolve SiraLex from a proven offline dictionary for the first language pai
 - The current importer, search key generation, and normalized record/search-index formats are already strong foundations and should be reused rather than replaced.
 - Do not treat large-scale search optimization as a Phase 3 blocker. Keep the architecture open for future indexing improvements, but do not over-engineer before real bundle scale requires it.
 
-### Phase 3.1 — Manifest language metadata
+### Phase 3.1 — Manifest language metadata ✅
 
 Extend `bundle.manifest.json` so the UI can describe the installed dictionary accurately.
+
+Status note: implemented in the manifest type/parser, bundle builder emission, and compatibility tests.
 
 Recommended metadata:
 
@@ -370,9 +374,11 @@ DoD:
 - A bundle can declare its language pair and display labels in the manifest.
 - The app can parse that metadata safely, with sensible fallback behavior when absent.
 
-### Phase 3.2 — Language-agnostic UI and direction semantics
+### Phase 3.2 — Language-agnostic UI and direction semantics ✅
 
 Replace language-specific frontend assumptions such as `FR → Maninka`, `Maninka → FR`, and enum values like `fr_to_mnk`.
+
+Status note: implemented with runtime-derived labels and `source_to_target` / `target_to_source` search semantics.
 
 Required direction semantics:
 
@@ -386,7 +392,7 @@ DoD:
 - Frontend runtime code no longer embeds a specific target language in its direction model.
 - Runtime search semantics enforce the selected direction instead of treating the toggle as display-only state.
 
-#### Phase 4.2.5 — Directional search semantics
+#### Phase 4.2.5 — Directional search semantics *(partially complete)*
 
 This mini-phase makes the direction toggle real at query time without changing the normalized record schema.
 
@@ -410,7 +416,13 @@ Current bundle-generation mapping:
 - `index_mapping` records emit `src_*` keys from `fields_raw.source_term`
 - `lexicon_entry` records emit `tgt_*` keys from headword/variant normalization
 
-**Recommended future: bundle-level capability flag**
+Current status:
+
+- directional `src_*` / `tgt_*` query execution is implemented
+- legacy fallback is still present for older bundles
+- the bundle-level capability flag is still not formalized in the typed manifest/runtime contract
+
+**Remaining future step: bundle-level capability flag**
 
 Right now the runtime tries the directional ladder first and falls back to the legacy (undirected) ladder only when the directional ladder returns zero results. That can create subtle ranking distortions later (e.g. directional bundle has a weak match, legacy fallback would have had a strong match → confusing ordering). To avoid hybrid logic:
 
@@ -420,9 +432,11 @@ Right now the runtime tries the directional ladder first and falls back to the l
 
 Then each bundle type has a single, predictable code path and no mixed ranking.
 
-### Phase 3.3 — Installed bundle registry
+### Phase 3.3 — Installed bundle registry ✅
 
 Phase 2 proved the runtime for one imported bundle. Phase 3 should make bundle installation explicit by tracking installed bundles locally.
+
+Status note: implemented with a dedicated bundle registry store plus active bundle metadata and install/update timestamps.
 
 Suggested local registry responsibilities:
 
@@ -434,9 +448,11 @@ Suggested local registry responsibilities:
 DoD:
 - The app can enumerate installed bundles and identify which bundle is active.
 
-### Phase 3.4 — Multi-bundle support
+### Phase 3.4 — Multi-bundle support ✅
 
 Support more than one dictionary bundle on the same device.
+
+Status note: implemented with bundle-scoped IndexedDB keys and active-bundle-scoped query/record resolution.
 
 The critical requirement is that storage and query behavior become **bundle-aware** before public multi-bundle release. The exact implementation can be a compound key, namespaced stores, or another equivalent IndexedDB strategy, but lookups must target the active bundle rather than implicitly assuming a single global dictionary.
 
@@ -466,19 +482,13 @@ DoD:
 - A user can select which installed dictionary is active.
 - The app has a documented path for catalog-driven bundle download/import, even if update logic remains minimal.
 
-### Explicitly deferred beyond Phase 3
+---
 
-These are valid future directions, but they should not be framed as Phase 3 prerequisites:
+## Phase 5 — Search/index quality improvement
 
-- prefix-range or Kindle-style narrowing indexes
-- advanced ranking/scoring heuristics
-- speculative performance work not justified by observed bundle size or device behavior
+This is now the next primary engineering milestone.
 
-Those belong in a later scaling/performance phase once real multi-bundle usage and device measurements justify them.
-
-### Phase 5+ problem — Search Index Granularity Improvement
-
-This is a real search-quality problem, but it is **not a Phase 4.3 blocker**. Phase 4.3 should continue on the current directional contract and runtime semantics.
+The current runtime can install, switch, update, and query bundles correctly, but search usefulness is still limited by the granularity and shape of the current index.
 
 Current limitation:
 
@@ -487,29 +497,60 @@ Current limitation:
 - this can reduce match quality for:
   - multiword phrases
   - punctuation-heavy glosses
-  - diacritics variants when users search partial or simplified forms
+  - diacritics and spacing variants
+  - partial phrase lookups
+  - N'Ko search quality once that surface becomes more important
 
-Scope for the later improvement:
+Primary scope:
 
-- break gloss into tokens
-- index atomic searchable units
-- possibly add n-gram / phrase indexing
-- improve matching for:
-  - multiword phrases
-  - punctuation-heavy glosses
-  - diacritics variants
+- tokenization
+- gloss splitting
+- phrase matching
+- diacritics/spacing behavior
+- N'Ko search quality
 
 Guardrails:
 
 - do not replace the current bundle/search contract prematurely
-- do not block directional indexing rollout on this work
-- base any tokenization or phrase-indexing rules on observed bundle behavior and real query needs, not speculative over-design
+- do not silently change search semantics without versioned bundle metadata
+- base tokenization and phrase-indexing rules on observed bundle behavior and real query needs, not speculative over-design
+- keep deterministic bundle generation as a non-negotiable constraint
 
-DoD (future):
+Current implementation direction:
 
-- the project has a documented, versioned indexing strategy for atomic units vs whole-string keys
-- real-bundle tests show better retrieval for phrase-heavy and punctuation-heavy source entries without regressing deterministic bundle generation
-- any new indexing mode is explicit in bundle metadata/versioning rather than silently changing search semantics
+- introduce `norm_v2` rather than mutating frozen `norm_v1`
+- keep the original `index_mapping.fields_raw.source_term` as-is
+- add deterministic extracted source phrases additively at normalization time
+- keep runtime query execution unchanged; improved retrieval comes from better
+  `src_*` / `tgt_*` key coverage, not from new client heuristics
+- include source-provided N'Ko headwords in target-side variants so `tgt_*`
+  keys can match real N'Ko queries
+
+DoD:
+
+- the project has a documented, versioned indexing strategy for whole-string keys versus atomic searchable units
+- real-bundle tests show materially better retrieval for phrase-heavy and punctuation-heavy source entries without regressing deterministic bundle generation
+- any new indexing/search mode is explicit in bundle metadata/versioning rather than silently changing runtime behavior
+
+### Parallel validation track — HTTPS deployment + iPhone offline validation
+
+This is important, but it is not the next core engineering milestone.
+
+Scope:
+
+- deploy the app shell over HTTPS
+- validate install/offline behavior on iPhone/iOS Safari for the shipped PWA flow
+- confirm the real constraints of offline app shell + IndexedDB + bundle installation on iOS
+
+### Explicitly deferred beyond Phase 5
+
+These are valid future directions, but they should not be framed as Phase 3 prerequisites:
+
+- prefix-range or Kindle-style narrowing indexes
+- advanced ranking/scoring heuristics
+- speculative performance work not justified by observed bundle size or device behavior
+
+Those belong in a later scaling/performance phase once real multi-bundle usage and device measurements justify them.
 
 ### Phase 2 memory constraint (lock-in before IndexedDB)
 
@@ -549,3 +590,5 @@ SiraLex is no longer just a single-dictionary app when:
 - Multiple bundles can be installed locally and selected explicitly
 - Search and record resolution are bundle-aware
 - The app has a defined path for catalog/download-based bundle installation
+
+Those conditions are now satisfied for the current runtime scope.

--- a/shared/normalization/manifest_v2.yaml
+++ b/shared/normalization/manifest_v2.yaml
@@ -1,0 +1,25 @@
+ruleset_id: norm_v2
+
+description: >
+  Additive search-quality ruleset. Reuses norm_v1 key transforms while
+  expanding the forms that feed them: index_mapping source terms gain
+  deterministic phrase extraction, and lexicon_entry target variants include
+  source-provided N'Ko headwords when available. Phrase extraction is
+  constrained by a minimum length, stopword filtering, and capped segment /
+  phrase counts to keep index growth controlled.
+
+changelog:
+  - version: norm_v2
+    date: "2026-04-25"
+    description: >
+      Preserve original source_term, add extracted source phrases for
+      gloss-like index entries, and include headword_nko_provided in
+      lexicon_entry variant_forms.
+
+data_files: []
+
+code_files:
+  - path: norm_v2.py
+    description: "norm_v2 phrase extraction and additive form selection"
+  - path: norm_v1.py
+    description: "Shared search-key transforms reused unchanged by norm_v2"

--- a/shared/normalization/norm_v2.py
+++ b/shared/normalization/norm_v2.py
@@ -1,0 +1,279 @@
+"""
+Normalization ruleset norm_v2.
+
+norm_v2 keeps the same per-string key transforms as norm_v1, but expands the
+set of forms that feed those transforms:
+
+- index_mapping source terms gain additive phrase variants extracted from
+  gloss-like strings
+- lexicon_entry target variants may include source-provided N'Ko headwords
+
+This module contains only pure functions.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from .norm_v1 import compute_search_keys, key_punct_stripped, normalize_nfc, normalize_whitespace
+
+RULESET_ID = "norm_v2"
+
+# Versioned source-phrase extraction policy. This is intentionally small and
+# explicit so the behavior stays reviewable and deterministic.
+MIN_SOURCE_PHRASE_LENGTH = 3
+MAX_SOURCE_SEGMENTS = 12
+MAX_SOURCE_PHRASES = 12
+SOURCE_STOPWORDS = frozenset({
+    "a",
+    "au",
+    "aux",
+    "c",
+    "ce",
+    "ces",
+    "cet",
+    "cette",
+    "d",
+    "dans",
+    "de",
+    "des",
+    "du",
+    "elle",
+    "elles",
+    "en",
+    "et",
+    "il",
+    "ils",
+    "je",
+    "la",
+    "le",
+    "les",
+    "leur",
+    "leurs",
+    "lui",
+    "ma",
+    "mais",
+    "mes",
+    "mon",
+    "ne",
+    "nos",
+    "notre",
+    "on",
+    "ou",
+    "par",
+    "pas",
+    "pour",
+    "qu",
+    "que",
+    "qui",
+    "sa",
+    "se",
+    "ses",
+    "son",
+    "sur",
+    "ta",
+    "te",
+    "tes",
+    "toi",
+    "ton",
+    "tu",
+    "un",
+    "une",
+    "vos",
+    "votre",
+    "vous",
+    "y",
+})
+
+_ENUMERATION_RE = re.compile(r"(?:^|[\s,;/])(?P<marker>(?:[A-Za-z]\)|\d+\.))\s+")
+_LEADING_ENUMERATION_RE = re.compile(r"^(?:[A-Za-z]\)|\d+\.)\s*")
+_TRAILING_PAREN_RE = re.compile(r"^(?P<body>.*?)(?:\s*\([^()]*\))$")
+
+
+def _strip_edge_punctuation(text: str) -> str:
+    text = normalize_whitespace(text)
+    if not text:
+        return ""
+
+    start = 0
+    end = len(text)
+    while start < end:
+        ch = text[start]
+        if ch.isspace() or unicodedata.category(ch).startswith("P"):
+            start += 1
+            continue
+        break
+
+    while end > start:
+        ch = text[end - 1]
+        if ch.isspace() or unicodedata.category(ch).startswith("P"):
+            end -= 1
+            continue
+        break
+
+    return normalize_whitespace(text[start:end])
+
+
+def _split_enumerations(text: str) -> list[str]:
+    text = normalize_whitespace(text)
+    if not text:
+        return []
+
+    matches = list(_ENUMERATION_RE.finditer(text))
+    if not matches:
+        return [text]
+
+    starts = [match.start("marker") for match in matches]
+    if starts[0] != 0:
+        return [text]
+
+    out: list[str] = []
+    for idx, start in enumerate(starts):
+        end = starts[idx + 1] if idx + 1 < len(starts) else len(text)
+        segment = normalize_whitespace(text[start:end])
+        segment = _LEADING_ENUMERATION_RE.sub("", segment)
+        if segment:
+            out.append(segment)
+    return out or [text]
+
+
+def _split_top_level_segments(text: str) -> list[str]:
+    """
+    Split on commas/semicolons/slashes only at top level.
+
+    This keeps multiword phrases intact and avoids exploding parenthetical
+    commentary into unrelated fragments.
+    """
+    text = normalize_whitespace(text)
+    if not text:
+        return []
+
+    out: list[str] = []
+    depth = 0
+    current: list[str] = []
+
+    for ch in text:
+        if ch == "(":
+            depth += 1
+            current.append(ch)
+            continue
+        if ch == ")":
+            depth = max(0, depth - 1)
+            current.append(ch)
+            continue
+        if depth == 0 and ch in ",;/":
+            segment = normalize_whitespace("".join(current))
+            if segment:
+                out.append(segment)
+                if len(out) >= MAX_SOURCE_SEGMENTS:
+                    return out
+            current = []
+            continue
+        current.append(ch)
+
+    segment = normalize_whitespace("".join(current))
+    if segment and len(out) < MAX_SOURCE_SEGMENTS:
+        out.append(segment)
+    return out
+
+
+def _segment_tokens(text: str) -> list[str]:
+    punct_stripped = key_punct_stripped(text)
+    if not punct_stripped:
+        return []
+    return [token for token in punct_stripped.split(" ") if token]
+
+
+def _is_noise_phrase(text: str) -> bool:
+    if len(text) < MIN_SOURCE_PHRASE_LENGTH:
+        return True
+
+    tokens = _segment_tokens(text)
+    if not tokens:
+        return True
+
+    return all(token in SOURCE_STOPWORDS for token in tokens)
+
+
+def _emit_exact_phrase(text: str, out: list[str], seen: set[str]) -> None:
+    if len(out) >= MAX_SOURCE_PHRASES:
+        return
+    candidate = normalize_whitespace(_LEADING_ENUMERATION_RE.sub("", text))
+    if not candidate or _is_noise_phrase(candidate):
+        return
+
+    dedupe_key = normalize_nfc(normalize_whitespace(candidate))
+    if dedupe_key in seen:
+        return
+
+    seen.add(dedupe_key)
+    out.append(candidate)
+
+
+def _emit_clean_phrase(text: str, out: list[str], seen: set[str]) -> None:
+    if len(out) >= MAX_SOURCE_PHRASES:
+        return
+    candidate = _strip_edge_punctuation(_LEADING_ENUMERATION_RE.sub("", text))
+    if not candidate or _is_noise_phrase(candidate):
+        return
+
+    dedupe_key = normalize_nfc(normalize_whitespace(candidate))
+    if dedupe_key in seen:
+        return
+
+    seen.add(dedupe_key)
+    out.append(candidate)
+
+
+def extract_source_phrases(source_term: str) -> list[str]:
+    """
+    Deterministically derive additive search phrases from an index source term.
+
+    Pipeline:
+    1. Preserve original
+    2. Split enumerations (a), b), 1., ...)
+    3. Split segments on commas, semicolons, slashes
+    4. For each segment, keep the full segment and, when present, a variant
+       without trailing parenthetical context
+    5. Strip leading/trailing punctuation
+    6. Filter short/noise phrases
+    7. Deduplicate, preserving order
+    """
+    if not source_term:
+        return []
+
+    phrases: list[str] = []
+    seen: set[str] = set()
+
+    # Preserve the original source term exactly as provided.
+    original = source_term if source_term.strip() else ""
+    if original:
+        seen.add(normalize_nfc(normalize_whitespace(original)))
+        phrases.append(original)
+
+    normalized = normalize_whitespace(source_term)
+    for enum_segment in _split_enumerations(normalized):
+        if len(phrases) >= MAX_SOURCE_PHRASES:
+            break
+
+        for raw_segment in _split_top_level_segments(enum_segment):
+            segment = normalize_whitespace(raw_segment)
+            if not segment:
+                continue
+
+            _emit_exact_phrase(segment, phrases, seen)
+
+            trailing_match = _TRAILING_PAREN_RE.match(segment)
+            if trailing_match:
+                body = normalize_whitespace(trailing_match.group("body"))
+                _emit_exact_phrase(body, phrases, seen)
+                _emit_clean_phrase(body, phrases, seen)
+            else:
+                _emit_clean_phrase(segment, phrases, seen)
+
+            if len(phrases) >= MAX_SOURCE_PHRASES:
+                break
+
+    return phrases
+

--- a/shared/specs/normalization-versioning.md
+++ b/shared/specs/normalization-versioning.md
@@ -247,6 +247,38 @@ When proposing `norm_v(N+1)`:
 - run the ruleset on the fixture set and review diffs
 - only then publish the new ruleset as the current default
 
+## `norm_v2` source-term decomposition contract
+
+`norm_v2` extends variant derivation for `index_mapping.fields_raw.source_term`
+without changing the underlying per-string key transforms from `norm_v1`.
+
+Normative contract:
+
+1. The full original `source_term` MUST be preserved as an emitted variant.
+2. Enumerations such as `a)`, `b)`, `1.`, `2.` MAY be split into additive
+   phrase candidates.
+3. Segment splitting MUST occur only on top-level commas, semicolons, and
+   slashes; delimiters inside parentheses MUST NOT create extra segments.
+4. If a segment ends with trailing parenthetical context, the ruleset MAY emit
+   both:
+   - the full segment
+   - a variant without that trailing parenthetical
+5. Cleaned variants MAY strip only leading/trailing punctuation; internal
+   multiword phrases MUST remain intact.
+6. Noise filtering MUST be deterministic and versioned. In `norm_v2` this
+   includes:
+   - minimum phrase length
+   - stopword-only filtering
+7. Token explosion MUST be bounded by explicit versioned limits. In `norm_v2`
+   this means:
+   - no whitespace tokenization
+   - capped top-level split segments per source term
+   - capped emitted phrases per source term
+
+These rules are additive alias-generation only. They MUST NOT replace the
+stored original source string, and they MUST NOT silently rewrite frozen
+`norm_v1` outputs in place.
+
 ## Minimal metadata contract (summary)
 
 Normalized records SHOULD be able to carry:

--- a/web/src/bundle_manifest.ts
+++ b/web/src/bundle_manifest.ts
@@ -57,12 +57,11 @@ export const EXPECTED_MANIFEST = {
   compression: "none",
   record_schema_id: "normalized_v1",
   record_schema_version: "1",
-  rule_versions: {
-    normalization: "norm_v1",
-  },
   reconciliation_action: "REPLACE_ALL",
   update_mode: "REPLACE_ALL",
 } as const;
+
+const NORMALIZATION_RULESET_RE = /^norm_v\d+$/;
 
 function isObject(x: unknown): x is Record<string, unknown> {
   return typeof x === "object" && x !== null;
@@ -203,12 +202,11 @@ export function parseAndValidateManifestJson(text: string): BundleManifestValida
       `record_schema_version mismatch: ${fmtExpected(record_schema_version, EXPECTED_MANIFEST.record_schema_version)}`,
     );
   }
-  if (normalization_ruleset && normalization_ruleset !== EXPECTED_MANIFEST.rule_versions.normalization) {
+  if (normalization_ruleset && !NORMALIZATION_RULESET_RE.test(normalization_ruleset)) {
     errors.push(
-      `rule_versions.normalization mismatch: ${fmtExpected(
-        normalization_ruleset,
-        EXPECTED_MANIFEST.rule_versions.normalization,
-      )}`,
+      `rule_versions.normalization mismatch: expected versioned norm_vN value, got '${
+        normalization_ruleset ?? "undefined"
+      }'`,
     );
   }
   if (reconciliation_action && reconciliation_action !== EXPECTED_MANIFEST.reconciliation_action) {

--- a/web/src/import/import_search_index.ts
+++ b/web/src/import/import_search_index.ts
@@ -41,6 +41,48 @@ export type SearchIndexEntry = {
   ir_ids: string[];
 };
 
+function describeError(e: unknown): {
+  error: unknown;
+  errorName?: string;
+  errorMessage?: string;
+  errorStack?: string;
+} {
+  if (e instanceof Error) {
+    return {
+      error: e,
+      errorName: e.name,
+      errorMessage: e.message,
+      errorStack: e.stack,
+    };
+  }
+  if (typeof e === "object" && e !== null) {
+    const maybe = e as { name?: unknown; message?: unknown; stack?: unknown };
+    return {
+      error: e,
+      errorName: typeof maybe.name === "string" ? maybe.name : undefined,
+      errorMessage: typeof maybe.message === "string" ? maybe.message : undefined,
+      errorStack: typeof maybe.stack === "string" ? maybe.stack : undefined,
+    };
+  }
+  return {
+    error: e,
+    errorMessage: String(e),
+  };
+}
+
+function summarizeEntry(entry: SearchIndexEntry | undefined) {
+  if (!entry) return undefined;
+  return {
+    key_type: entry.key_type,
+    key:
+      entry.key.length > 160
+        ? `${entry.key.slice(0, 157)}...`
+        : entry.key,
+    ir_ids_count: entry.ir_ids.length,
+    ir_ids_sample: entry.ir_ids.slice(0, 3),
+  };
+}
+
 export async function importSearchIndexJsonl(
   db: IDBDatabase,
   indexFile: JsonlByteSource,
@@ -58,6 +100,14 @@ export async function importSearchIndexJsonl(
   let entriesWritten = 0;
   let batchesCommitted = 0;
   const duplicateKeysFound: string[] = [];
+  let lastProcessedLineNumber = 0;
+  let currentPhase:
+    | "stream"
+    | "json-parse"
+    | "validation"
+    | "store.put"
+    | "txDone"
+    | "idle" = "stream";
 
   const batch: SearchIndexEntry[] = [];
   const batchKeySet = debugDetectDuplicateKeys ? new Set<string>() : undefined;
@@ -71,77 +121,125 @@ export async function importSearchIndexJsonl(
 
   async function flushBatch() {
     if (batch.length === 0) return;
+    const batchNumber = batchesCommitted + 1;
+    const batchStartLineNumber = linesSeen - batch.length + 1;
+    const batchEndLineNumber = linesSeen;
+    let firstRequestError:
+      | {
+          requestIndex: number;
+          errorName?: string;
+          errorMessage?: string;
+        }
+      | undefined;
     const tx = db.transaction(STORE_SEARCH_INDEX, "readwrite");
     const store = tx.objectStore(STORE_SEARCH_INDEX);
-    for (const entry of batch) {
-      store.put(entry);
+    currentPhase = "store.put";
+    for (const [requestIndex, entry] of batch.entries()) {
+      const req = store.put(entry);
+      req.addEventListener("error", () => {
+        const reqDetails = describeError(req.error);
+        if (!firstRequestError) {
+          firstRequestError = {
+            requestIndex,
+            errorName: reqDetails.errorName,
+            errorMessage: reqDetails.errorMessage,
+          };
+        }
+      });
     }
-    await txDone(tx);
+    try {
+      currentPhase = "txDone";
+      await txDone(tx);
+    } catch (e) {
+      const details = describeError(e);
+      const txDetails = describeError(tx.error);
+      throw new Error(
+        `search_index.jsonl transaction failed in batch ${batchNumber} (lines ${batchStartLineNumber}-${batchEndLineNumber}) after ${entriesWritten} committed entries at line ${lastProcessedLineNumber}: ${details.errorMessage ?? String(e)}; tx.error=${txDetails.errorName ?? "unknown"}:${txDetails.errorMessage ?? "unknown"}; firstRequestError=${
+          firstRequestError
+            ? `${firstRequestError.requestIndex}@line${batchStartLineNumber + firstRequestError.requestIndex}:${firstRequestError.errorName ?? "unknown"}:${firstRequestError.errorMessage ?? "unknown"}`
+            : "none"
+        }; firstEntry=${JSON.stringify(summarizeEntry(batch[0]))}; lastEntry=${JSON.stringify(summarizeEntry(batch[batch.length - 1]))}`,
+      );
+    }
     batchesCommitted += 1;
     entriesWritten += batch.length;
     batch.length = 0;
     batchKeySet?.clear();
+    currentPhase = "idle";
     report();
     await nextAnimationFrame();
   }
 
-  for await (const line of streamJsonlLines(indexFile, { onProgress: handleStreamProgress, signal })) {
-    if (signal?.aborted) {
-      throw signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason ?? "Aborted"));
-    }
-    linesSeen += 1;
-
-    let obj: unknown;
-    try {
-      obj = JSON.parse(line) as unknown;
-    } catch (e) {
-      throw new Error(`search_index.jsonl parse error on line ${linesSeen}: ${String(e)}`);
-    }
-
-    if (typeof obj !== "object" || obj === null) {
-      throw new Error(`search_index.jsonl line ${linesSeen}: expected object, got ${typeof obj}`);
-    }
-    const rec = obj as Record<string, unknown>;
-    const keyType = rec["key_type"];
-    const key = rec["key"];
-    const irIds = rec["ir_ids"];
-
-    if (typeof keyType !== "string" || keyType.trim() === "") {
-      throw new Error(`search_index.jsonl line ${linesSeen}: missing/invalid key_type`);
-    }
-    if (typeof key !== "string" || key.trim() === "") {
-      throw new Error(`search_index.jsonl line ${linesSeen}: missing/invalid key`);
-    }
-    if (!Array.isArray(irIds)) {
-      throw new Error(`search_index.jsonl line ${linesSeen}: missing/invalid ir_ids (array)`);
-    }
-    const ids: string[] = [];
-    for (const x of irIds) {
-      if (typeof x !== "string" || x.trim() === "") continue;
-      ids.push(x);
-    }
-    if (ids.length === 0) {
-      throw new Error(`search_index.jsonl line ${linesSeen}: ir_ids[] is empty or non-string`);
-    }
-
-    if (batchKeySet) {
-      const compoundKey = `${bundleId}\0${keyType}\0${key}`;
-      if (batchKeySet.has(compoundKey)) {
-        duplicateKeysFound.push(
-          `search_index line ${linesSeen}: duplicate [${bundleId}, ${keyType}, ${key}] within batch`,
-        );
+  try {
+    for await (const line of streamJsonlLines(indexFile, { onProgress: handleStreamProgress, signal })) {
+      currentPhase = "stream";
+      if (signal?.aborted) {
+        throw signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason ?? "Aborted"));
       }
-      batchKeySet.add(compoundKey);
+      linesSeen += 1;
+      lastProcessedLineNumber = linesSeen;
+
+      let obj: unknown;
+      try {
+        currentPhase = "json-parse";
+        obj = JSON.parse(line) as unknown;
+      } catch (e) {
+        throw new Error(`search_index.jsonl parse error on line ${linesSeen}: ${String(e)}`);
+      }
+
+      currentPhase = "validation";
+      if (typeof obj !== "object" || obj === null) {
+        throw new Error(`search_index.jsonl line ${linesSeen}: expected object, got ${typeof obj}`);
+      }
+      const rec = obj as Record<string, unknown>;
+      const keyType = rec["key_type"];
+      const key = rec["key"];
+      const irIds = rec["ir_ids"];
+
+      if (typeof keyType !== "string" || keyType.trim() === "") {
+        throw new Error(`search_index.jsonl line ${linesSeen}: missing/invalid key_type`);
+      }
+      if (typeof key !== "string" || key.trim() === "") {
+        throw new Error(`search_index.jsonl line ${linesSeen}: missing/invalid key`);
+      }
+      if (!Array.isArray(irIds)) {
+        throw new Error(`search_index.jsonl line ${linesSeen}: missing/invalid ir_ids (array)`);
+      }
+      const ids: string[] = [];
+      for (const x of irIds) {
+        if (typeof x !== "string" || x.trim() === "") continue;
+        ids.push(x);
+      }
+      if (ids.length === 0) {
+        throw new Error(`search_index.jsonl line ${linesSeen}: ir_ids[] is empty or non-string`);
+      }
+
+      if (batchKeySet) {
+        const compoundKey = `${bundleId}\0${keyType}\0${key}`;
+        if (batchKeySet.has(compoundKey)) {
+          duplicateKeysFound.push(
+            `search_index line ${linesSeen}: duplicate [${bundleId}, ${keyType}, ${key}] within batch`,
+          );
+        }
+        batchKeySet.add(compoundKey);
+      }
+
+      batch.push({ bundle_id: bundleId, key_type: keyType, key, ir_ids: ids });
+      if (batch.length >= batchSize) {
+        await flushBatch();
+      }
     }
 
-    batch.push({ bundle_id: bundleId, key_type: keyType, key, ir_ids: ids });
-    if (batch.length >= batchSize) {
-      await flushBatch();
-    }
+    await flushBatch();
+    report();
+  } catch (e) {
+    const details = describeError(e);
+    throw new Error(
+      `importSearchIndexJsonl failed during ${currentPhase}: ${details.errorMessage ?? String(e)}; linesSeen=${linesSeen}; entriesWritten=${entriesWritten}; batchesCommitted=${batchesCommitted}; lastProcessedLineNumber=${lastProcessedLineNumber}; pendingBatchSize=${batch.length}; pendingBatchLines=${
+        batch.length > 0 ? `${linesSeen - batch.length + 1}-${linesSeen}` : "none"
+      }; firstEntry=${JSON.stringify(summarizeEntry(batch[0]))}; lastEntry=${JSON.stringify(summarizeEntry(batch[batch.length - 1]))}`,
+    );
   }
-
-  await flushBatch();
-  report();
 
   return { entriesWritten, linesSeen, batchesCommitted, duplicateKeysFound };
 }

--- a/web/src/import/jsonl_stream.ts
+++ b/web/src/import/jsonl_stream.ts
@@ -23,6 +23,10 @@ export type StreamJsonlOptions = {
 
 export type JsonlByteSource = Blob | ReadableStream<Uint8Array>;
 
+function errorToString(e: unknown): string {
+  return e instanceof Error ? `${e.name}: ${e.message}` : String(e);
+}
+
 function throwIfAborted(signal: AbortSignal | undefined) {
   if (signal?.aborted) {
     throw signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason ?? "Aborted"));
@@ -82,7 +86,15 @@ export async function* streamJsonlLines(
   try {
     while (true) {
       throwIfAborted(signal);
-      const { value, done } = await reader.read();
+      let readResult: ReadableStreamReadResult<Uint8Array>;
+      try {
+        readResult = await reader.read();
+      } catch (e) {
+        throw new Error(
+          `JSONL stream reader error after ${bytesRead} bytes and ${linesEmitted} lines: ${errorToString(e)}`,
+        );
+      }
+      const { value, done } = readResult;
       if (done) break;
       if (!value) continue;
 

--- a/web/src/install/bundle_install.ts
+++ b/web/src/install/bundle_install.ts
@@ -30,7 +30,7 @@ import {
 } from "../import/import_search_index";
 import type { JsonlByteSource } from "../import/jsonl_stream";
 
-export const DEFAULT_BUNDLE_FETCH_TIMEOUT_MS = 30_000;
+export const DEFAULT_BUNDLE_FETCH_START_TIMEOUT_MS = 30_000;
 
 export type InstallBundleResult = {
   recordsCount: number;
@@ -140,30 +140,38 @@ async function fetchBodyStream(
   url: string,
   expectedBytes: number,
   fetchImpl: typeof fetch,
-  signal: AbortSignal,
+  signal: AbortSignal | undefined,
+  responseStartTimeoutMs: number,
   currentBaseUrl?: string,
 ): Promise<ReadableStream<Uint8Array>> {
-  const response = await fetchImpl(url, {
-    headers: { Accept: "application/octet-stream,application/json,text/plain" },
-    signal,
-  });
-  if (!response.ok) {
-    throw new Error(`Bundle request failed: ${response.status} ${response.statusText} (${url})`);
-  }
-  validateRemoteUrlPolicy(response.url || url, currentBaseUrl);
-
-  const contentLength = response.headers.get("content-length");
-  if (contentLength) {
-    const parsed = Number(contentLength);
-    if (Number.isFinite(parsed) && parsed !== expectedBytes) {
-      throw new Error(`Remote payload byte_length mismatch: expected ${expectedBytes}, got ${parsed}`);
+  const timeout = createLinkedAbortSignal(responseStartTimeoutMs, signal);
+  try {
+    const response = await fetchImpl(url, {
+      headers: { Accept: "application/octet-stream,application/json,text/plain" },
+      signal: timeout.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`Bundle request failed: ${response.status} ${response.statusText} (${url})`);
     }
-  }
-  if (!response.body) {
-    throw new Error(`Bundle response body missing for ${url}`);
-  }
+    validateRemoteUrlPolicy(response.url || url, currentBaseUrl);
 
-  return createByteLengthValidatedStream(response.body, expectedBytes);
+    const contentLength = response.headers.get("content-length");
+    if (contentLength) {
+      const parsed = Number(contentLength);
+      if (Number.isFinite(parsed) && parsed !== expectedBytes) {
+        throw new Error(`Remote payload byte_length mismatch: expected ${expectedBytes}, got ${parsed}`);
+      }
+    }
+    if (!response.body) {
+      throw new Error(`Bundle response body missing for ${url}`);
+    }
+
+    // Once the response body is available, do not enforce a total elapsed
+    // timeout while bytes are actively being streamed and imported.
+    return createByteLengthValidatedStream(response.body, expectedBytes);
+  } finally {
+    timeout.cleanup();
+  }
 }
 
 function computeManifestPayloadBytes(manifest: BundleManifestV1): number | undefined {
@@ -239,6 +247,7 @@ export async function installBundleIntoDb(
   let recordsCount = 0;
   let indexCount = 0;
   let cleanupWarning: string | undefined;
+  let stage = "staging: records import";
   try {
     const recRes = await importRecordsJsonl(db, sources.recordsSource, {
       bundleId: nextStorageScopeId,
@@ -258,6 +267,7 @@ export async function installBundleIntoDb(
     });
     recordsCount = recRes.recordsWritten;
 
+    stage = "staging: search_index import";
     const idxRes = await importSearchIndexJsonl(db, sources.searchIndexSource, {
       bundleId: nextStorageScopeId,
       batchSize: 500,
@@ -277,6 +287,7 @@ export async function installBundleIntoDb(
     });
     indexCount = idxRes.entriesWritten;
 
+    stage = "committing bundle metadata";
     const installedMeta = buildInstalledBundleMeta(manifest, nextStorageScopeId, recordsCount, indexCount, metadata);
     if (activateOnCommit) {
       await setActiveBundleMeta(db, installedMeta);
@@ -292,6 +303,7 @@ export async function installBundleIntoDb(
     });
 
     if (previousStorageScopeId && previousStorageScopeId !== nextStorageScopeId) {
+      stage = "cleanup: previous bundle scope removal";
       try {
         await deleteBundleScopeData(db, previousStorageScopeId);
         await clearBundleInstallSession(db);
@@ -301,6 +313,7 @@ export async function installBundleIntoDb(
           `Cleanup will be retried on next app load.`;
       }
     } else {
+      stage = "cleanup: clear install session";
       await clearBundleInstallSession(db);
     }
   } catch (e) {
@@ -325,111 +338,115 @@ export async function installRemoteCatalogBundle(
 ): Promise<{ manifest: BundleManifestV1; result: InstallBundleResult }> {
   const onUpdate = options.onUpdate ?? (() => undefined);
   const fetchImpl = options.fetchImpl ?? fetch;
-  const timeoutMs = options.timeoutMs ?? DEFAULT_BUNDLE_FETCH_TIMEOUT_MS;
-  const { signal, cleanup } = createLinkedAbortSignal(timeoutMs, options.signal);
+  const responseStartTimeoutMs = options.timeoutMs ?? DEFAULT_BUNDLE_FETCH_START_TIMEOUT_MS;
+  const signal = options.signal;
 
+  const urls = deriveBundleAssetUrls(catalogUrl, entry);
+  onUpdate(`Installing ${entry.bundle_id}\nStage: fetching manifest\n`);
+  const manifestTimeout = createLinkedAbortSignal(responseStartTimeoutMs, signal);
+  let manifestResponse: Response;
   try {
-    const urls = deriveBundleAssetUrls(catalogUrl, entry);
-    onUpdate(`Installing ${entry.bundle_id}\nStage: fetching manifest\n`);
-    const manifestResponse = await fetchImpl(urls.manifest_url, {
+    manifestResponse = await fetchImpl(urls.manifest_url, {
       headers: { Accept: "application/json" },
-      signal,
+      signal: manifestTimeout.signal,
     });
-    if (!manifestResponse.ok) {
-      throw new Error(`Bundle request failed: ${manifestResponse.status} ${manifestResponse.statusText} (${urls.manifest_url})`);
-    }
-    validateRemoteUrlPolicy(manifestResponse.url || urls.manifest_url, catalogUrl);
-    const manifestText = await manifestResponse.text();
-    const parsed = parseAndValidateManifestJson(manifestText);
-    if (!parsed.ok || !parsed.manifest) {
-      throw new Error(`Manifest validation failed: ${parsed.errors.join("; ")}`);
-    }
-
-    const manifest = parsed.manifest;
-    if (manifest.bundle_id !== entry.bundle_id) {
-      throw new Error(
-        `Catalog/manifest bundle_id mismatch: catalog=${entry.bundle_id}, manifest=${manifest.bundle_id}`,
-      );
-    }
-    if (manifest.content_sha256 !== entry.content_sha256) {
-      throw new Error(
-        `Catalog/manifest content_sha256 mismatch: catalog=${entry.content_sha256}, manifest=${manifest.content_sha256}`,
-      );
-    }
-
-    const installed = await getInstalledBundleMeta(db, entry.bundle_id);
-    if (installed?.expected_content_sha256 === entry.content_sha256) {
-      const installedMeta = {
-        ...installed,
-        imported_at_iso: installed.imported_at_iso,
-      };
-      if (options.activateOnCommit ?? true) {
-        await setActiveBundleMeta(db, installedMeta);
-      } else {
-        await putInstalledBundleMeta(db, installedMeta);
-      }
-      return {
-        manifest,
-        result: {
-          recordsCount: installed.records_count ?? 0,
-          indexCount: installed.index_entries_count ?? 0,
-          elapsedMs: 0,
-          skippedBecauseCurrent: true,
-        },
-      };
-    }
-
-    const recordsEntry = getManifestFileEntry(manifest, "records.jsonl");
-    const indexEntry = getManifestFileEntry(manifest, "search_index.jsonl");
-
-    if (options.storageEstimate) {
-      const estimate = await options.storageEstimate();
-      const usage = estimate.usage ?? 0;
-      const quota = estimate.quota;
-      const requiredBytes = recordsEntry.byte_length + indexEntry.byte_length;
-      if (typeof quota === "number" && quota - usage < requiredBytes) {
-        throw new Error(
-          `Insufficient storage headroom: need ${requiredBytes} bytes, have ${Math.max(0, quota - usage)} bytes`,
-        );
-      }
-    }
-
-    onUpdate(`Installing ${entry.bundle_id}\nStage: fetching records.jsonl\n`);
-    const recordsStream = await fetchBodyStream(
-      urls.records_url,
-      recordsEntry.byte_length,
-      fetchImpl,
-      signal,
-      catalogUrl,
-    );
-    onUpdate(`Installing ${entry.bundle_id}\nStage: fetching search_index.jsonl\n`);
-    const indexStream = await fetchBodyStream(
-      urls.search_index_url,
-      indexEntry.byte_length,
-      fetchImpl,
-      signal,
-      catalogUrl,
-    );
-
-    const result = await installBundleIntoDb(
-      db,
-      manifest,
-      {
-        recordsSource: recordsStream,
-        searchIndexSource: indexStream,
-      },
-      onUpdate,
-      signal,
-      {
-        displayName: entry.name,
-        version: entry.version,
-        storageBytes: entry.size_bytes,
-      },
-      options.activateOnCommit ?? true,
-    );
-
-    return { manifest, result };
   } finally {
-    cleanup();
+    manifestTimeout.cleanup();
   }
+  if (!manifestResponse.ok) {
+    throw new Error(`Bundle request failed: ${manifestResponse.status} ${manifestResponse.statusText} (${urls.manifest_url})`);
+  }
+  validateRemoteUrlPolicy(manifestResponse.url || urls.manifest_url, catalogUrl);
+  const manifestText = await manifestResponse.text();
+  const parsed = parseAndValidateManifestJson(manifestText);
+  if (!parsed.ok || !parsed.manifest) {
+    throw new Error(`Manifest validation failed: ${parsed.errors.join("; ")}`);
+  }
+
+  const manifest = parsed.manifest;
+  if (manifest.bundle_id !== entry.bundle_id) {
+    throw new Error(
+      `Catalog/manifest bundle_id mismatch: catalog=${entry.bundle_id}, manifest=${manifest.bundle_id}`,
+    );
+  }
+  if (manifest.content_sha256 !== entry.content_sha256) {
+    throw new Error(
+      `Catalog/manifest content_sha256 mismatch: catalog=${entry.content_sha256}, manifest=${manifest.content_sha256}`,
+    );
+  }
+
+  const installed = await getInstalledBundleMeta(db, entry.bundle_id);
+  if (installed?.expected_content_sha256 === entry.content_sha256) {
+    const installedMeta = {
+      ...installed,
+      imported_at_iso: installed.imported_at_iso,
+    };
+    if (options.activateOnCommit ?? true) {
+      await setActiveBundleMeta(db, installedMeta);
+    } else {
+      await putInstalledBundleMeta(db, installedMeta);
+    }
+    return {
+      manifest,
+      result: {
+        recordsCount: installed.records_count ?? 0,
+        indexCount: installed.index_entries_count ?? 0,
+        elapsedMs: 0,
+        skippedBecauseCurrent: true,
+      },
+    };
+  }
+
+  const recordsEntry = getManifestFileEntry(manifest, "records.jsonl");
+  const indexEntry = getManifestFileEntry(manifest, "search_index.jsonl");
+
+  if (options.storageEstimate) {
+    const estimate = await options.storageEstimate();
+    const usage = estimate.usage ?? 0;
+    const quota = estimate.quota;
+    const requiredBytes = recordsEntry.byte_length + indexEntry.byte_length;
+    if (typeof quota === "number" && quota - usage < requiredBytes) {
+      throw new Error(
+        `Insufficient storage headroom: need ${requiredBytes} bytes, have ${Math.max(0, quota - usage)} bytes`,
+      );
+    }
+  }
+
+  onUpdate(`Installing ${entry.bundle_id}\nStage: fetching records.jsonl\n`);
+  const recordsStream = await fetchBodyStream(
+    urls.records_url,
+    recordsEntry.byte_length,
+    fetchImpl,
+    signal,
+    responseStartTimeoutMs,
+    catalogUrl,
+  );
+  onUpdate(`Installing ${entry.bundle_id}\nStage: fetching search_index.jsonl\n`);
+  const indexStream = await fetchBodyStream(
+    urls.search_index_url,
+    indexEntry.byte_length,
+    fetchImpl,
+    signal,
+    responseStartTimeoutMs,
+    catalogUrl,
+  );
+
+  const result = await installBundleIntoDb(
+    db,
+    manifest,
+    {
+      recordsSource: recordsStream,
+      searchIndexSource: indexStream,
+    },
+    onUpdate,
+    signal,
+    {
+      displayName: entry.name,
+      version: entry.version,
+      storageBytes: entry.size_bytes,
+    },
+    options.activateOnCommit ?? true,
+  );
+
+  return { manifest, result };
 }

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -231,6 +231,23 @@ let remoteInstallAbortController: AbortController | undefined;
 let remoteInstallBundleId: string | undefined;
 let currentStorageEstimate: { usage?: number; quota?: number } | undefined;
 
+function formatErrorDetails(e: unknown): string {
+  const details = [`String(e): ${String(e)}`];
+  if (e && typeof e === "object") {
+    const maybeError = e as {
+      name?: unknown;
+      message?: unknown;
+      stack?: unknown;
+    };
+    details.push(`e.name: ${String(maybeError.name ?? "")}`);
+    details.push(`e.message: ${String(maybeError.message ?? "")}`);
+    if (maybeError.stack !== undefined) {
+      details.push(`e.stack:\n${String(maybeError.stack)}`);
+    }
+  }
+  return details.join("\n");
+}
+
 function fmtBytes(n: number | undefined): string {
   if (n === undefined) return "n/a";
   const units = ["B", "KB", "MB", "GB"];
@@ -1078,7 +1095,10 @@ async function installCatalogEntry(entry: BundleCatalogEntryV1, activateOnCommit
       }
     }
   } catch (e) {
-    importProgress.textContent = `Remote install failed: ${String(e)}\n`;
+    console.error("REMOTE INSTALL FAILED", e);
+    importProgress.textContent =
+      `Install FAILED\n` +
+      `${formatErrorDetails(e)}\n`;
   } finally {
     remoteInstallAbortController = undefined;
     remoteInstallBundleId = undefined;

--- a/web/src/phase3_bundle_runtime.test.ts
+++ b/web/src/phase3_bundle_runtime.test.ts
@@ -84,6 +84,32 @@ describe("Phase 3 manifest parsing", () => {
     expect(result.manifest?.language_labels).toEqual({ source: "French", target: "Maninka" });
     expect(result.manifest?.scripts).toEqual({ target_supported: ["latin", "nko"] });
   });
+
+  it("accepts versioned normalization rulesets beyond norm_v1", () => {
+    const result = parseAndValidateManifestJson(
+      JSON.stringify({
+        manifest_schema_version: "bundle_manifest_v1",
+        bundle_id: "bundle_full_norm_v2_22222222",
+        bundle_type: "full",
+        bundle_format: "directory",
+        compression: "none",
+        record_schema_id: "normalized_v1",
+        record_schema_version: "1",
+        rule_versions: { normalization: "norm_v2" },
+        sources: { included: ["src_malipense"], excluded: [] },
+        reconciliation_action: "REPLACE_ALL",
+        update_mode: "REPLACE_ALL",
+        files: [
+          { path: "records.jsonl", byte_length: 10, sha256: "sha256:aaa" },
+          { path: "search_index.jsonl", byte_length: 20, sha256: "sha256:bbb" },
+        ],
+        content_sha256: "sha256:ccc",
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.manifest?.rule_versions.normalization).toBe("norm_v2");
+  });
 });
 
 describe("Phase 3 bundle-aware runtime", () => {
@@ -204,6 +230,70 @@ describe("Phase 3 bundle-aware runtime", () => {
       expect(result.ir_ids).toEqual(["rec-a"]);
       records = await resolveRecords(db, bundleA, result.ir_ids);
       expect(records.map((record) => record.ir_id)).toEqual(["rec-a"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("resolves norm_v2 phrase and N'Ko keys while keeping directions isolated", async () => {
+    const db = await openSiralexDb();
+    try {
+      const bundleId = "bundle_full_norm_v2_search";
+
+      await importRecordsJsonl(
+        db,
+        makeJsonlFile("records.jsonl", [
+          {
+            ir_id: "rec-source",
+            ir_kind: "index_mapping",
+            source_id: "src_malipense",
+            norm_version: "norm_v2",
+            preferred_form: "a) bon travail! (une salutation), b) merci! (pour un travail)",
+            variant_forms: [
+              "a) bon travail! (une salutation), b) merci! (pour un travail)",
+              "bon travail",
+              "merci",
+              "bon réveil",
+            ],
+            search_keys: {
+              casefold: ["bon travail", "merci", "bon réveil"],
+            },
+            display: { source_term: "a) bon travail! (une salutation), b) merci! (pour un travail)" },
+          },
+          {
+            ir_id: "rec-target",
+            ir_kind: "lexicon_entry",
+            source_id: "src_malipense",
+            norm_version: "norm_v2",
+            preferred_form: "dàa",
+            variant_forms: ["dàa", "ߘߊ߰"],
+            search_keys: {
+              casefold: ["dàa", "ߘߊ߰"],
+            },
+            display: { headword_latin: "dàa", headword_nko_provided: "ߘߊ߰" },
+          },
+        ]),
+        { bundleId, batchSize: 10 },
+      );
+      await importSearchIndexJsonl(
+        db,
+        makeJsonlFile("search_index.jsonl", [
+          { key_type: "src_casefold", key: "bon travail", ir_ids: ["rec-source"] },
+          { key_type: "src_casefold", key: "merci", ir_ids: ["rec-source"] },
+          { key_type: "src_casefold", key: "bon réveil", ir_ids: ["rec-source"] },
+          { key_type: "tgt_casefold", key: "ߘߊ߰", ir_ids: ["rec-target"] },
+        ]),
+        { bundleId, batchSize: 10 },
+      );
+
+      expect((await searchQuery(db, bundleId, "source_to_target", "bon travail")).ir_ids).toEqual(["rec-source"]);
+      expect((await searchQuery(db, bundleId, "source_to_target", "merci")).ir_ids).toEqual(["rec-source"]);
+      expect((await searchQuery(db, bundleId, "source_to_target", "bon réveil")).ir_ids).toEqual(["rec-source"]);
+      expect((await searchQuery(db, bundleId, "source_to_target", "bon re\u0301veil")).ir_ids).toEqual(["rec-source"]);
+      expect((await searchQuery(db, bundleId, "target_to_source", "ߘߊ߰")).ir_ids).toEqual(["rec-target"]);
+
+      expect((await searchQuery(db, bundleId, "target_to_source", "bon travail")).ir_ids).toEqual([]);
+      expect((await searchQuery(db, bundleId, "source_to_target", "ߘߊ߰")).ir_ids).toEqual([]);
     } finally {
       db.close();
     }

--- a/web/src/phase4_remote_install.test.ts
+++ b/web/src/phase4_remote_install.test.ts
@@ -50,6 +50,23 @@ function makeLineChunkedStream(text: string): ReadableStream<Uint8Array> {
   });
 }
 
+function makeDelayedLineChunkedStream(text: string, delayMs: number): ReadableStream<Uint8Array> {
+  const lines = text.match(/[^\n]*\n|[^\n]+$/g) ?? [];
+  const encoder = new TextEncoder();
+  let index = 0;
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (index >= lines.length) {
+        controller.close();
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      controller.enqueue(encoder.encode(lines[index]!));
+      index += 1;
+    },
+  });
+}
+
 function makeResponse(body: string, contentType: string): Response {
   const bytes = new TextEncoder().encode(body);
   return new Response(makeStream(body), {
@@ -64,6 +81,22 @@ function makeResponse(body: string, contentType: string): Response {
 function makeResponseWithUrl(body: string, contentType: string, url: string, chunked = false): Response {
   const bytes = new TextEncoder().encode(body);
   const response = new Response(chunked ? makeLineChunkedStream(body) : makeStream(body), {
+    status: 200,
+    headers: {
+      "content-type": contentType,
+      "content-length": String(bytes.byteLength),
+    },
+  });
+  Object.defineProperty(response, "url", {
+    value: url,
+    configurable: true,
+  });
+  return response;
+}
+
+function makeDelayedResponseWithUrl(body: string, contentType: string, url: string, delayMs: number): Response {
+  const bytes = new TextEncoder().encode(body);
+  const response = new Response(makeDelayedLineChunkedStream(body, delayMs), {
     status: 200,
     headers: {
       "content-type": contentType,
@@ -210,6 +243,98 @@ describe("Phase 4.2 remote install", () => {
       expect(resultIds.ir_ids).toEqual(["rec-1"]);
       const records = await resolveRecords(db, active!.storage_scope_id!, resultIds.ir_ids);
       expect(records.map((record) => record.ir_id)).toEqual(["rec-1"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not timeout an active payload stream just because total elapsed time exceeds response-start timeout", async () => {
+    const recordsText = makeJsonl([
+      {
+        ir_id: "rec-slow",
+        ir_kind: "lexicon_entry",
+        source_id: "src_slow",
+        norm_version: "norm_v1",
+        preferred_form: "slow-entry",
+        variant_forms: ["slow-entry"],
+        search_keys: { casefold: ["slow-hello"] },
+        display: { headword_latin: "slow-entry" },
+      },
+    ]);
+    const indexText = makeJsonl([
+      { key_type: "tgt_casefold", key: "slow-hello", ir_ids: ["rec-slow"] },
+      { key_type: "tgt_casefold", key: "slow-hello-2", ir_ids: ["rec-slow"] },
+      { key_type: "tgt_casefold", key: "slow-hello-3", ir_ids: ["rec-slow"] },
+    ]);
+    const manifestText = JSON.stringify({
+      manifest_schema_version: "bundle_manifest_v1",
+      bundle_id: "maninka_fr_slow",
+      bundle_type: "full",
+      bundle_format: "directory",
+      compression: "none",
+      record_schema_id: "normalized_v1",
+      record_schema_version: "1",
+      rule_versions: { normalization: "norm_v1" },
+      sources: { included: ["src"], excluded: [] },
+      reconciliation_action: "REPLACE_ALL",
+      update_mode: "REPLACE_ALL",
+      files: [
+        {
+          path: "records.jsonl",
+          byte_length: new TextEncoder().encode(recordsText).byteLength,
+          sha256: "sha256:records-slow",
+        },
+        {
+          path: "search_index.jsonl",
+          byte_length: new TextEncoder().encode(indexText).byteLength,
+          sha256: "sha256:index-slow",
+        },
+      ],
+      content_sha256: "sha256:bundle-slow",
+    });
+
+    const entry: BundleCatalogEntryV1 = {
+      bundle_id: "maninka_fr_slow",
+      name: "French ↔ Maninka Slow Stream",
+      version: "1.0.0",
+      size_bytes: new TextEncoder().encode(recordsText).byteLength + new TextEncoder().encode(indexText).byteLength,
+      url_base: "./bundles/maninka_fr_slow/",
+      content_sha256: "sha256:bundle-slow",
+    };
+
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = String(input);
+      if (url.endsWith("/bundle.manifest.json")) {
+        return makeResponseWithUrl(manifestText, "application/json", url);
+      }
+      if (url.endsWith("/records.jsonl")) {
+        return makeDelayedResponseWithUrl(recordsText, "application/json", url, 4);
+      }
+      if (url.endsWith("/search_index.jsonl")) {
+        return makeDelayedResponseWithUrl(indexText, "application/json", url, 4);
+      }
+      return new Response("not found", { status: 404, statusText: "Not Found" });
+    };
+
+    const db = await openSiralexDb();
+    try {
+      const { manifest, result } = await installRemoteCatalogBundle(
+        db,
+        entry,
+        "https://example.test/catalog.json",
+        {
+          fetchImpl,
+          timeoutMs: 5,
+        },
+      );
+
+      expect(manifest.bundle_id).toBe("maninka_fr_slow");
+      expect(result.recordsCount).toBe(1);
+      expect(result.indexCount).toBe(3);
+
+      const active = await getActiveBundleMeta(db);
+      expect(active?.bundle_id).toBe("maninka_fr_slow");
+      expect(active?.storage_scope_id).toBe("maninka_fr_slow::sha256:bundle-slow");
     } finally {
       db.close();
     }

--- a/web/src/search/search_query.ts
+++ b/web/src/search/search_query.ts
@@ -15,7 +15,7 @@
  */
 
 import { STORE_SEARCH_INDEX } from "../idb/siralex_db";
-import { computeSearchKeys, type SearchKeys } from "../norm/norm_v1";
+import { computeSearchKeys, normalizeNfc, type SearchKeys } from "../norm/norm_v1";
 import type { SearchDirection } from "../bundle_labels";
 
 const KEY_TYPE_ORDER: (keyof SearchKeys)[] = [
@@ -73,7 +73,7 @@ export async function searchQuery(
     return { ir_ids: [], matched_key_type: null, matched_key: null };
   }
 
-  const keys = computeSearchKeys([trimmed]);
+  const keys = computeSearchKeys([normalizeNfc(trimmed)]);
 
   const tx = db.transaction(STORE_SEARCH_INDEX, "readonly");
   const store = tx.objectStore(STORE_SEARCH_INDEX);


### PR DESCRIPTION
Improve real-bundle lookup quality with versioned additive source phrase extraction and N'Ko target variants, while keeping runtime search semantics stable. Prevent valid long-running remote bundle installs from failing by limiting timeouts to response start instead of active payload streaming.

## What does this PR change?

- 

## Why?

- 

## Checklist (required)

- [ ] I kept this PR narrowly scoped.
- [ ] If I changed language data / meaning, I explained the impact and any uncertainty.
- [ ] If this touches third-party sources, I preserved attribution and did not add content without permission.
- [ ] If this changes normalization/transliteration behavior, I added examples (inputs → outputs) in the PR description.

## Screenshots / notes (if applicable)

- 

