### PR TITLE
feat(corrections): add deterministic dry-run correction pipeline

### DIFF
--- a/api/corrections/__init__.py
+++ b/api/corrections/__init__.py
@@ -1,0 +1,2 @@
+"""Correction dry-run pipeline package."""
+

--- a/api/corrections/cli.py
+++ b/api/corrections/cli.py
@@ -1,0 +1,86 @@
+"""CLI entrypoint for correction dry-run application."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from .dry_run_apply import run_corrections_dry_run
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Apply approved correction records to an IR snapshot in dry-run mode"
+    )
+    parser.add_argument("--ir-input", type=Path, required=True, help="Input IR JSONL (immutable)")
+    parser.add_argument(
+        "--ir-version",
+        type=str,
+        required=True,
+        help="IR version context; must equal correctionset manifest target_ir_version",
+    )
+    parser.add_argument(
+        "--correctionset-manifest",
+        type=Path,
+        required=True,
+        help="Correctionset manifest JSON path",
+    )
+    parser.add_argument(
+        "--corrections-jsonl",
+        type=Path,
+        required=True,
+        help="Correction records JSONL path",
+    )
+    parser.add_argument("--output-ir", type=Path, required=True, help="Corrected IR output JSONL path")
+    parser.add_argument(
+        "--output-report",
+        type=Path,
+        required=True,
+        help="Machine-readable dry-run report JSON path",
+    )
+    parser.add_argument(
+        "--output-manifest",
+        type=Path,
+        required=False,
+        default=None,
+        help="Optional corrected IR manifest JSON output path",
+    )
+    parser.add_argument(
+        "--generated-at",
+        type=str,
+        required=False,
+        default=None,
+        help="Deterministic generated_at timestamp (ISO-8601 UTC Z)",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(levelname)s: %(message)s",
+    )
+
+    result = run_corrections_dry_run(
+        ir_input_path=args.ir_input,
+        correctionset_manifest_path=args.correctionset_manifest,
+        corrections_jsonl_path=args.corrections_jsonl,
+        input_ir_version=args.ir_version,
+        output_ir_path=args.output_ir,
+        output_report_path=args.output_report,
+        output_manifest_path=args.output_manifest,
+        generated_at=args.generated_at,
+    )
+
+    print("Correction dry-run completed.")
+    print(f"Corrected IR sha256: {result.corrected_ir_sha256}")
+    print(f"Report sha256:       {result.report_sha256}")
+    print("Summary:")
+    for key, value in sorted(result.summary.items()):
+        print(f"  {key}: {value}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/api/corrections/conflicts.py
+++ b/api/corrections/conflicts.py
@@ -1,0 +1,119 @@
+"""Supersession and same-target conflict handling."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from .models import CorrectionRecord, Rejection
+from .patching import parse_pointer
+
+
+def apply_supersession_filter(
+    approved_records: list[CorrectionRecord],
+) -> tuple[list[CorrectionRecord], list[Rejection]]:
+    by_id = {record.correction_id: record for record in approved_records}
+    superseded_ids: set[str] = set()
+
+    for record in approved_records:
+        supersedes = (
+            record.raw.get("provenance", {})
+            .get("audit", {})
+            .get("supersedes_correction_id")
+        )
+        if not isinstance(supersedes, str) or not supersedes:
+            continue
+        if supersedes in by_id and supersedes != record.correction_id:
+            superseded_ids.add(supersedes)
+
+    kept: list[CorrectionRecord] = []
+    rejections: list[Rejection] = []
+    for record in approved_records:
+        if record.correction_id in superseded_ids:
+            rejections.append(
+                Rejection(
+                    correction_id=record.correction_id,
+                    target_ir_id=record.target_ir_id,
+                    reason_code="superseded_by_newer_correction",
+                    detail="excluded by supersession reference from another approved correction",
+                )
+            )
+            continue
+        kept.append(record)
+
+    return kept, rejections
+
+
+def _paths_overlap(path_a: str, path_b: str) -> bool:
+    tokens_a = parse_pointer(path_a)
+    tokens_b = parse_pointer(path_b)
+    min_len = min(len(tokens_a), len(tokens_b))
+    if tokens_a[:min_len] == tokens_b[:min_len]:
+        return True
+    return False
+
+
+def _is_array_shift_risk_op(op: dict) -> bool:
+    op_name = op.get("op")
+    if op_name not in {"add", "remove"}:
+        return False
+    path = op.get("path")
+    if not isinstance(path, str):
+        return False
+    tokens = parse_pointer(path)
+    return any(token == "-" or token.isdigit() for token in tokens)
+
+
+def apply_same_target_conflict_policy(
+    records: list[CorrectionRecord],
+) -> tuple[list[CorrectionRecord], list[Rejection]]:
+    grouped: dict[str, list[CorrectionRecord]] = defaultdict(list)
+    for record in records:
+        grouped[record.target_ir_id].append(record)
+
+    kept: list[CorrectionRecord] = []
+    rejections: list[Rejection] = []
+
+    for target_ir_id in sorted(grouped.keys()):
+        group = sorted(grouped[target_ir_id], key=lambda rec: rec.correction_id)
+        if len(group) == 1:
+            kept.append(group[0])
+            continue
+
+        if any(_is_array_shift_risk_op(op) for rec in group for op in rec.patch):
+            for record in group:
+                rejections.append(
+                    Rejection(
+                        correction_id=record.correction_id,
+                        target_ir_id=record.target_ir_id,
+                        reason_code="conflict_same_target_array_shift_risk",
+                        detail="same-target group contains add/remove on array-indexed path",
+                    )
+                )
+            continue
+
+        all_paths = [str(op.get("path", "")) for rec in group for op in rec.patch]
+        has_overlap = False
+        for i in range(len(all_paths)):
+            for j in range(i + 1, len(all_paths)):
+                if _paths_overlap(all_paths[i], all_paths[j]):
+                    has_overlap = True
+                    break
+            if has_overlap:
+                break
+
+        if has_overlap:
+            for record in group:
+                rejections.append(
+                    Rejection(
+                        correction_id=record.correction_id,
+                        target_ir_id=record.target_ir_id,
+                        reason_code="conflict_same_target_overlapping_paths",
+                        detail="same-target group has overlapping JSON pointer paths",
+                    )
+                )
+            continue
+
+        kept.extend(group)
+
+    return kept, rejections
+

--- a/api/corrections/dry_run_apply.py
+++ b/api/corrections/dry_run_apply.py
@@ -1,0 +1,266 @@
+"""Dry-run correction application engine."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .conflicts import apply_same_target_conflict_policy, apply_supersession_filter
+from .helpers import (
+    canonical_json,
+    now_utc_iso,
+    parse_iso8601_utc,
+    sha256_prefixed_bytes,
+    sha256_prefixed_text,
+)
+from .lifecycle import resolve_latest_lifecycle_records
+from .loaders import load_correctionset, load_ir_jsonl
+from .models import ApplyResult, CorrectionRecord, Rejection
+from .patching import PatchError, apply_patch
+from .validators import preflight_patch, validate_semantic, validate_structural
+
+
+def _rejection_to_report_entry(rejection: Rejection) -> dict[str, Any]:
+    return {
+        "correction_id": rejection.correction_id,
+        "target_ir_id": rejection.target_ir_id,
+        "disposition": "rejected" if not rejection.reason_code.startswith("conflict_") else "conflicted",
+        "reason_code": rejection.reason_code,
+        "detail": rejection.detail,
+    }
+
+
+def _safe_timestamp_sort(value: Any) -> tuple[int, str]:
+    if not isinstance(value, str):
+        return (1, "")
+    try:
+        parsed = parse_iso8601_utc(value)
+    except ValueError:
+        return (1, "")
+    return (0, parsed.isoformat())
+
+
+def _apply_sort_key(record: CorrectionRecord) -> tuple[str, tuple[int, str], str, int]:
+    submitted_at = record.raw.get("timestamps", {}).get("submitted_at")
+    return (
+        record.target_ir_id,
+        _safe_timestamp_sort(submitted_at),
+        record.correction_id,
+        record.source_line_number,
+    )
+
+
+def _write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for record in records:
+            f.write(canonical_json(record) + "\n")
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(canonical_json(payload))
+        f.write("\n")
+
+
+def _index_ir_records(records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    indexed: dict[str, dict[str, Any]] = {}
+    for record in records:
+        ir_id = record.get("ir_id")
+        if isinstance(ir_id, str):
+            indexed[ir_id] = record
+    return indexed
+
+
+def run_corrections_dry_run(
+    *,
+    ir_input_path: Path,
+    correctionset_manifest_path: Path,
+    corrections_jsonl_path: Path,
+    input_ir_version: str,
+    output_ir_path: Path,
+    output_report_path: Path,
+    output_manifest_path: Path | None,
+    generated_at: str | None = None,
+) -> ApplyResult:
+    correctionset = load_correctionset(correctionset_manifest_path, corrections_jsonl_path)
+    if input_ir_version != correctionset.manifest.target_ir_version:
+        raise ValueError(
+            "fatal version mismatch: input IR version context must equal correctionset.manifest.target_ir_version"
+        )
+
+    run_timestamp = generated_at or now_utc_iso()
+    # Validate deterministic timestamp input early.
+    parse_iso8601_utc(run_timestamp)
+
+    ir_records = load_ir_jsonl(ir_input_path)
+    ir_by_id = _index_ir_records(ir_records)
+
+    report_entries: list[dict[str, Any]] = []
+    structural_valid: list[CorrectionRecord] = []
+
+    for record in correctionset.records:
+        structural_errors = validate_structural(record)
+        if structural_errors:
+            report_entries.extend(_rejection_to_report_entry(err) for err in structural_errors)
+            continue
+        structural_valid.append(record)
+
+    latest_records, lifecycle_rejections = resolve_latest_lifecycle_records(structural_valid)
+    report_entries.extend(_rejection_to_report_entry(err) for err in lifecycle_rejections)
+
+    approved_records: list[CorrectionRecord] = []
+    for record in latest_records:
+        if record.status != "approved":
+            report_entries.append(
+                _rejection_to_report_entry(
+                    Rejection(
+                        correction_id=record.correction_id,
+                        target_ir_id=record.target_ir_id,
+                        reason_code="not_approved_status",
+                        detail=f"latest status is {record.status!r}",
+                    )
+                )
+            )
+            continue
+        approved_records.append(record)
+
+    eligible_count = len(approved_records)
+
+    semantic_valid: list[CorrectionRecord] = []
+    for record in approved_records:
+        semantic_errors = validate_semantic(
+            record=record,
+            target_record=ir_by_id.get(record.target_ir_id),
+            correctionset_target_version=correctionset.manifest.target_ir_version,
+        )
+        if semantic_errors:
+            report_entries.extend(_rejection_to_report_entry(err) for err in semantic_errors)
+            continue
+        semantic_valid.append(record)
+
+    supersession_kept, supersession_rejections = apply_supersession_filter(semantic_valid)
+    report_entries.extend(_rejection_to_report_entry(err) for err in supersession_rejections)
+
+    preflight_valid: list[CorrectionRecord] = []
+    for record in supersession_kept:
+        target = ir_by_id[record.target_ir_id]
+        preflight_errors = preflight_patch(record, target)
+        if preflight_errors:
+            report_entries.extend(_rejection_to_report_entry(err) for err in preflight_errors)
+            continue
+        preflight_valid.append(record)
+
+    conflict_free, conflict_rejections = apply_same_target_conflict_policy(preflight_valid)
+    report_entries.extend(_rejection_to_report_entry(err) for err in conflict_rejections)
+
+    candidates_by_target: dict[str, list[CorrectionRecord]] = {}
+    for record in sorted(conflict_free, key=_apply_sort_key):
+        candidates_by_target.setdefault(record.target_ir_id, []).append(record)
+
+    applied_correction_ids: list[str] = []
+    output_records: list[dict[str, Any]] = []
+
+    for original in ir_records:
+        ir_id = original.get("ir_id")
+        if not isinstance(ir_id, str) or ir_id not in candidates_by_target:
+            output_records.append(original)
+            continue
+
+        current = original
+        for correction in candidates_by_target[ir_id]:
+            try:
+                current = apply_patch(current, correction.patch)
+                applied_correction_ids.append(correction.correction_id)
+                report_entries.append(
+                    {
+                        "correction_id": correction.correction_id,
+                        "target_ir_id": correction.target_ir_id,
+                        "disposition": "applied_in_dry_run",
+                        "reason_code": None,
+                        "detail": None,
+                    }
+                )
+            except PatchError as exc:
+                report_entries.append(
+                    _rejection_to_report_entry(
+                        Rejection(
+                            correction_id=correction.correction_id,
+                            target_ir_id=correction.target_ir_id,
+                            reason_code="patch_apply_failed",
+                            detail=str(exc),
+                        )
+                    )
+                )
+        output_records.append(current)
+
+    _write_jsonl(output_ir_path, output_records)
+    corrected_ir_sha256 = sha256_prefixed_bytes(output_ir_path.read_bytes())
+
+    conflicted_count = sum(1 for entry in report_entries if entry["disposition"] == "conflicted")
+    applied_count = sum(1 for entry in report_entries if entry["disposition"] == "applied_in_dry_run")
+    rejected_non_conflict = sum(
+        1 for entry in report_entries if entry["disposition"] == "rejected"
+    )
+
+    summary = {
+        "eligible": eligible_count,
+        "applied_in_dry_run": applied_count,
+        "rejected": rejected_non_conflict,
+        "conflicted": conflicted_count,
+        "skipped_non_approved": sum(1 for e in report_entries if e["reason_code"] == "not_approved_status"),
+        "invalid_structural": sum(1 for e in report_entries if e["reason_code"] == "invalid_structural"),
+        "invalid_semantic": sum(
+            1
+            for e in report_entries
+            if e["reason_code"]
+            in {"target_ir_id_not_found", "target_snapshot_version_mismatch", "target_snapshot_hash_mismatch"}
+        ),
+    }
+
+    report_payload = {
+        "schema_id": "correction_application_report_v1",
+        "dry_run": True,
+        "generated_at": run_timestamp,
+        "correctionset_id": correctionset.manifest.correctionset_id,
+        "correctionset_version": correctionset.manifest.correctionset_version,
+        "base_ir_version": input_ir_version,
+        "summary": summary,
+        "corrections": sorted(
+            report_entries,
+            key=lambda e: (
+                str(e.get("target_ir_id", "")),
+                str(e.get("correction_id", "")),
+                str(e.get("disposition", "")),
+                str(e.get("reason_code", "")),
+            ),
+        ),
+    }
+    _write_json(output_report_path, report_payload)
+    report_sha256 = sha256_prefixed_bytes(output_report_path.read_bytes())
+
+    if output_manifest_path is not None:
+        output_manifest = {
+            "schema_id": "corrected_ir_manifest_v1",
+            "dry_run": True,
+            "generated_at": run_timestamp,
+            "base_ir_version": input_ir_version,
+            "correctionset_id": correctionset.manifest.correctionset_id,
+            "correctionset_version": correctionset.manifest.correctionset_version,
+            "input_ir_path": str(ir_input_path),
+            "output_ir_path": str(output_ir_path),
+            "output_report_path": str(output_report_path),
+            "input_ir_sha256": sha256_prefixed_text(ir_input_path.read_text(encoding="utf-8")),
+            "output_ir_sha256": corrected_ir_sha256,
+            "output_report_sha256": report_sha256,
+        }
+        _write_json(output_manifest_path, output_manifest)
+
+    return ApplyResult(
+        corrected_ir_sha256=corrected_ir_sha256,
+        report_sha256=report_sha256,
+        summary=summary,
+    )
+

--- a/api/corrections/helpers.py
+++ b/api/corrections/helpers.py
@@ -1,0 +1,42 @@
+"""Utility helpers for deterministic correction processing."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_hex_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_prefixed(value: Any) -> str:
+    return f"sha256:{sha256_hex_bytes(canonical_json(value).encode('utf-8'))}"
+
+
+def sha256_prefixed_text(text: str) -> str:
+    return f"sha256:{sha256_hex_bytes(text.encode('utf-8'))}"
+
+
+def sha256_prefixed_bytes(data: bytes) -> str:
+    return f"sha256:{sha256_hex_bytes(data)}"
+
+
+def parse_iso8601_utc(value: str) -> datetime:
+    if not value.endswith("Z"):
+        raise ValueError("timestamp must use UTC Z suffix")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def now_utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+

--- a/api/corrections/lifecycle.py
+++ b/api/corrections/lifecycle.py
@@ -1,0 +1,66 @@
+"""Lifecycle resolution for correction records."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+
+from .helpers import canonical_json, parse_iso8601_utc
+from .models import CorrectionRecord, Rejection
+
+
+def _updated_at_key(record: CorrectionRecord) -> datetime:
+    try:
+        return parse_iso8601_utc(record.updated_at)
+    except ValueError:
+        return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def resolve_latest_lifecycle_records(
+    records: list[CorrectionRecord],
+) -> tuple[list[CorrectionRecord], list[Rejection]]:
+    """
+    Keep only latest lifecycle row per correction_id.
+
+    Active per-record tie-breakers (single-correctionset mode):
+    1. timestamps.updated_at descending
+    2. source line number descending
+    3. canonical JSON string descending
+
+    Note: correctionset_version is manifest-level and shared in this mode, so it is
+    intentionally non-operative here. It is reserved for future multi-correctionset
+    ingestion modes.
+    """
+    grouped: dict[str, list[CorrectionRecord]] = defaultdict(list)
+    for record in records:
+        grouped[record.correction_id].append(record)
+
+    latest_records: list[CorrectionRecord] = []
+    rejections: list[Rejection] = []
+
+    for correction_id in sorted(grouped.keys()):
+        group = grouped[correction_id]
+        sorted_group = sorted(
+            group,
+            key=lambda rec: (
+                _updated_at_key(rec),
+                rec.source_line_number,
+                canonical_json(rec.raw),
+            ),
+            reverse=True,
+        )
+        latest = sorted_group[0]
+        latest_records.append(latest)
+
+        for older in sorted_group[1:]:
+            rejections.append(
+                Rejection(
+                    correction_id=older.correction_id,
+                    target_ir_id=older.target_ir_id,
+                    reason_code="non_latest_lifecycle_version",
+                    detail=f"superseded by newer lifecycle row for correction_id={correction_id}",
+                )
+            )
+
+    return latest_records, rejections
+

--- a/api/corrections/loaders.py
+++ b/api/corrections/loaders.py
@@ -1,0 +1,135 @@
+"""Loaders for correctionset manifests, correction records, and IR snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from .helpers import parse_iso8601_utc
+from .models import CorrectionRecord, CorrectionSet, CorrectionSetManifest
+
+
+def load_correctionset_manifest(path: Path) -> CorrectionSetManifest:
+    with open(path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+
+    return CorrectionSetManifest(
+        correctionset_id=str(raw.get("correctionset_id", "")),
+        correctionset_version=str(raw.get("correctionset_version", "")),
+        schema_id=str(raw.get("schema_id", "")),
+        created_at=str(raw.get("created_at", "")),
+        target_ir_version=str(raw.get("target_ir_version", "")),
+        files=raw.get("files", []) if isinstance(raw.get("files", []), list) else [],
+        content_sha256=str(raw.get("content_sha256", "")),
+    )
+
+
+def _validate_manifest_contract(manifest: CorrectionSetManifest) -> None:
+    if manifest.schema_id != "correctionset_manifest_v1":
+        raise ValueError("invalid correctionset manifest: schema_id must be correctionset_manifest_v1")
+    if not manifest.correctionset_id:
+        raise ValueError("invalid correctionset manifest: correctionset_id is required")
+    if not manifest.correctionset_version:
+        raise ValueError("invalid correctionset manifest: correctionset_version is required")
+    if not manifest.created_at:
+        raise ValueError("invalid correctionset manifest: created_at is required")
+    parse_iso8601_utc(manifest.created_at)
+    if not manifest.target_ir_version:
+        raise ValueError("invalid correctionset manifest: target_ir_version is required")
+    if not manifest.content_sha256:
+        raise ValueError("invalid correctionset manifest: content_sha256 is required")
+    if not manifest.files:
+        raise ValueError("invalid correctionset manifest: files[] is required")
+
+    for idx, entry in enumerate(manifest.files):
+        if not isinstance(entry, dict):
+            raise ValueError(f"invalid correctionset manifest: files[{idx}] must be object")
+        required_keys = {"path", "sha256", "byte_length"}
+        missing = required_keys - set(entry.keys())
+        if missing:
+            raise ValueError(
+                f"invalid correctionset manifest: files[{idx}] missing keys: {', '.join(sorted(missing))}"
+            )
+        if not isinstance(entry["path"], str) or not entry["path"]:
+            raise ValueError(f"invalid correctionset manifest: files[{idx}].path must be non-empty string")
+        if not isinstance(entry["sha256"], str) or not entry["sha256"].startswith("sha256:"):
+            raise ValueError(
+                f"invalid correctionset manifest: files[{idx}].sha256 must be sha256:... string"
+            )
+        if not isinstance(entry["byte_length"], int) or entry["byte_length"] < 0:
+            raise ValueError(f"invalid correctionset manifest: files[{idx}].byte_length must be >= 0 int")
+
+
+def _validate_corrections_file_integrity(
+    manifest: CorrectionSetManifest, corrections_path: Path
+) -> None:
+    matches = [
+        entry for entry in manifest.files
+        if Path(str(entry["path"])).name == corrections_path.name
+    ]
+    if not matches:
+        raise ValueError(
+            "invalid correctionset manifest: files[] must include corrections JSONL entry"
+        )
+    entry = matches[0]
+    expected_size = int(entry["byte_length"])
+    actual_size = corrections_path.stat().st_size
+    if actual_size != expected_size:
+        raise ValueError(
+            "corrections.jsonl integrity mismatch: byte_length differs from manifest"
+        )
+
+    data = corrections_path.read_bytes()
+    actual_sha = f"sha256:{hashlib.sha256(data).hexdigest()}"
+    expected_sha = str(entry["sha256"])
+    if actual_sha != expected_sha:
+        raise ValueError(
+            "corrections.jsonl integrity mismatch: sha256 differs from manifest"
+        )
+
+
+def load_corrections_jsonl(path: Path) -> list[CorrectionRecord]:
+    records: list[CorrectionRecord] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line_number, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            raw = json.loads(line)
+            if not isinstance(raw, dict):
+                raise ValueError(f"corrections line {line_number} must be a JSON object")
+            records.append(
+                CorrectionRecord(
+                    raw=raw,
+                    source_line_number=line_number,
+                    source_file=str(path),
+                )
+            )
+    return records
+
+
+def load_correctionset(manifest_path: Path, corrections_path: Path) -> CorrectionSet:
+    manifest = load_correctionset_manifest(manifest_path)
+    _validate_manifest_contract(manifest)
+    _validate_corrections_file_integrity(manifest, corrections_path)
+    # Deliberately deferred in v1 implementation: verification of manifest.content_sha256
+    # canonicalization semantics. This remains explicitly deferred by spec.
+    records = load_corrections_jsonl(corrections_path)
+    return CorrectionSet(manifest=manifest, records=records)
+
+
+def load_ir_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line_number, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            raw = json.loads(line)
+            if not isinstance(raw, dict):
+                raise ValueError(f"IR line {line_number} must be a JSON object")
+            records.append(raw)
+    return records
+

--- a/api/corrections/models.py
+++ b/api/corrections/models.py
@@ -1,0 +1,70 @@
+"""Data models for correction dry-run processing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CorrectionSetManifest:
+    correctionset_id: str
+    correctionset_version: str
+    schema_id: str
+    created_at: str
+    target_ir_version: str
+    files: list[dict[str, Any]]
+    content_sha256: str
+
+
+@dataclass(frozen=True)
+class CorrectionRecord:
+    raw: dict[str, Any]
+    source_line_number: int
+    source_file: str
+
+    @property
+    def correction_id(self) -> str:
+        return str(self.raw.get("correction_id", ""))
+
+    @property
+    def target_ir_id(self) -> str:
+        return str(self.raw.get("target_ir_id", ""))
+
+    @property
+    def status(self) -> str:
+        return str(self.raw.get("status", ""))
+
+    @property
+    def patch(self) -> list[dict[str, Any]]:
+        value = self.raw.get("patch", [])
+        return value if isinstance(value, list) else []
+
+    @property
+    def updated_at(self) -> str:
+        timestamps = self.raw.get("timestamps", {})
+        if not isinstance(timestamps, dict):
+            return ""
+        return str(timestamps.get("updated_at", ""))
+
+
+@dataclass(frozen=True)
+class CorrectionSet:
+    manifest: CorrectionSetManifest
+    records: list[CorrectionRecord]
+
+
+@dataclass(frozen=True)
+class Rejection:
+    correction_id: str
+    target_ir_id: str
+    reason_code: str
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    corrected_ir_sha256: str
+    report_sha256: str
+    summary: dict[str, int]
+

--- a/api/corrections/patching.py
+++ b/api/corrections/patching.py
@@ -1,0 +1,129 @@
+"""RFC 6902 subset patch application helpers for correction dry-run."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+ALLOWED_PATCH_OPS = {"add", "remove", "replace"}
+
+
+class PatchError(ValueError):
+    """Raised when patch application fails."""
+
+
+def decode_json_pointer_token(token: str) -> str:
+    decoded_chars: list[str] = []
+    i = 0
+    while i < len(token):
+        ch = token[i]
+        if ch != "~":
+            decoded_chars.append(ch)
+            i += 1
+            continue
+        if i + 1 >= len(token):
+            raise PatchError("invalid JSON Pointer escape: trailing '~'")
+        esc = token[i + 1]
+        if esc == "0":
+            decoded_chars.append("~")
+        elif esc == "1":
+            decoded_chars.append("/")
+        else:
+            raise PatchError(f"invalid JSON Pointer escape: '~{esc}'")
+        i += 2
+    return "".join(decoded_chars)
+
+
+def parse_pointer(path: str) -> list[str]:
+    if not path.startswith("/"):
+        raise PatchError("path must start with /")
+    return [decode_json_pointer_token(token) for token in path[1:].split("/")]
+
+
+def _as_int_index(token: str) -> int:
+    if token == "-":
+        raise PatchError("'-' index is only allowed for add")
+    try:
+        return int(token)
+    except ValueError as exc:
+        raise PatchError(f"invalid array index token: {token!r}") from exc
+
+
+def _get_parent_and_token(root: Any, pointer_tokens: list[str]) -> tuple[Any, str]:
+    if not pointer_tokens:
+        raise PatchError("empty pointer is not supported")
+    node = root
+    for token in pointer_tokens[:-1]:
+        if isinstance(node, dict):
+            if token not in node:
+                raise PatchError(f"object key does not exist: {token!r}")
+            node = node[token]
+            continue
+        if isinstance(node, list):
+            index = _as_int_index(token)
+            if index < 0 or index >= len(node):
+                raise PatchError(f"array index out of bounds: {index}")
+            node = node[index]
+            continue
+        raise PatchError("pointer traversal reached scalar value")
+    return node, pointer_tokens[-1]
+
+
+def apply_patch_op(root: Any, op: dict[str, Any]) -> None:
+    op_name = op.get("op")
+    path = op.get("path")
+    if not isinstance(op_name, str) or op_name not in ALLOWED_PATCH_OPS:
+        raise PatchError(f"unsupported op: {op_name!r}")
+    if not isinstance(path, str):
+        raise PatchError("path must be a string")
+
+    tokens = parse_pointer(path)
+    parent, token = _get_parent_and_token(root, tokens)
+
+    if isinstance(parent, dict):
+        if op_name == "add":
+            parent[token] = op.get("value")
+            return
+        if op_name == "remove":
+            if token not in parent:
+                raise PatchError(f"object key not found for remove: {token!r}")
+            del parent[token]
+            return
+        if op_name == "replace":
+            if token not in parent:
+                raise PatchError(f"object key not found for replace: {token!r}")
+            parent[token] = op.get("value")
+            return
+        raise PatchError(f"unsupported op: {op_name!r}")
+
+    if isinstance(parent, list):
+        if op_name == "add":
+            if token == "-":
+                parent.append(op.get("value"))
+                return
+            index = _as_int_index(token)
+            if index < 0 or index > len(parent):
+                raise PatchError(f"array index out of bounds for add: {index}")
+            parent.insert(index, op.get("value"))
+            return
+        index = _as_int_index(token)
+        if index < 0 or index >= len(parent):
+            raise PatchError(f"array index out of bounds: {index}")
+        if op_name == "remove":
+            parent.pop(index)
+            return
+        if op_name == "replace":
+            parent[index] = op.get("value")
+            return
+        raise PatchError(f"unsupported op: {op_name!r}")
+
+    raise PatchError("pointer parent is not container type")
+
+
+def apply_patch(document: dict[str, Any], patch_ops: list[dict[str, Any]]) -> dict[str, Any]:
+    patched = deepcopy(document)
+    for op in patch_ops:
+        apply_patch_op(patched, op)
+    return patched
+

--- a/api/corrections/tests/test_dry_run_pipeline.py
+++ b/api/corrections/tests/test_dry_run_pipeline.py
@@ -1,0 +1,637 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from corrections.dry_run_apply import run_corrections_dry_run
+from corrections.helpers import sha256_prefixed, sha256_prefixed_bytes
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def _make_ir_record(ir_id: str, gloss: str) -> dict:
+    return {
+        "ir_id": ir_id,
+        "ir_kind": "lexicon_entry",
+        "source_id": "src_test",
+        "fields_raw": {
+            "senses": [{"gloss_fr": gloss}],
+        },
+    }
+
+
+def _make_correction_record(
+    correction_id: str,
+    target_ir_id: str,
+    *,
+    status: str = "approved",
+    patch: list[dict] | None = None,
+    updated_at: str = "2026-05-16T15:00:00Z",
+    submitted_at: str | None = "2026-05-16T14:00:00Z",
+    decided_at: str | None = "2026-05-16T15:00:00Z",
+    reviewed_at: str | None = "2026-05-16T15:00:00Z",
+    supersedes: str | None = None,
+    ir_version: str = "ir_v1",
+    record_sha256: str | None = None,
+) -> dict:
+    return {
+        "schema_id": "correction_record_v1",
+        "schema_version": 1,
+        "correction_id": correction_id,
+        "target_ir_id": target_ir_id,
+        "patch": patch
+        or [
+            {
+                "op": "replace",
+                "path": "/fields_raw/senses/0/gloss_fr",
+                "value": f"corrected:{correction_id}",
+            }
+        ],
+        "submitter": {"anonymous_token": "anon_0123456789abcdef"},
+        "timestamps": {
+            "created_at": "2026-05-16T13:00:00Z",
+            "updated_at": updated_at,
+            "submitted_at": submitted_at,
+            "reviewed_at": reviewed_at,
+            "decided_at": decided_at,
+            "applied_at": None,
+        },
+        "status": status,
+        "provenance": {
+            "reason": "test",
+            "target_snapshot": {
+                "ir_version": ir_version,
+                "record_sha256": record_sha256,
+            },
+            "audit": {
+                "submitted_via": "manual_import",
+                "reviewer_token": None,
+                "decision_note": None,
+                "supersedes_correction_id": supersedes,
+            },
+        },
+    }
+
+
+def _make_manifest(corrections_path: Path, *, schema_id: str = "correctionset_manifest_v1") -> dict:
+    data = corrections_path.read_bytes()
+    return {
+        "correctionset_id": "corrset_test",
+        "correctionset_version": "1",
+        "schema_id": schema_id,
+        "created_at": "2026-05-16T15:00:00Z",
+        "target_ir_version": "ir_v1",
+        "files": [
+            {"path": "corrections.jsonl", "sha256": sha256_prefixed_bytes(data), "byte_length": len(data)},
+        ],
+        "content_sha256": "sha256:test",
+    }
+
+
+def test_valid_single_correction_applies(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+
+    correction = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        record_sha256=sha256_prefixed(ir_records[0]),
+    )
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [correction])
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, _make_manifest(corrections_path))
+
+    out_ir = tmp_path / "out.jsonl"
+    out_report = tmp_path / "report.json"
+    result = run_corrections_dry_run(
+        ir_input_path=ir_path,
+        correctionset_manifest_path=manifest_path,
+        corrections_jsonl_path=corrections_path,
+        input_ir_version="ir_v1",
+        output_ir_path=out_ir,
+        output_report_path=out_report,
+        output_manifest_path=None,
+        generated_at="2026-05-16T15:01:00Z",
+    )
+
+    rows = _read_jsonl(out_ir)
+    assert rows[0]["fields_raw"]["senses"][0]["gloss_fr"] == "corrected:corr_20260516_000001"
+    assert result.summary["eligible"] == 1
+    assert result.summary["applied_in_dry_run"] == 1
+
+
+def test_multiple_independent_corrections_apply(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old1"), _make_ir_record("ir_2", "old2")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+
+    corrections = [
+        _make_correction_record("corr_20260516_000001", "ir_1", record_sha256=sha256_prefixed(ir_records[0])),
+        _make_correction_record("corr_20260516_000002", "ir_2", record_sha256=sha256_prefixed(ir_records[1])),
+    ]
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, corrections)
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, _make_manifest(corrections_path))
+
+    out_ir = tmp_path / "out.jsonl"
+    out_report = tmp_path / "report.json"
+    result = run_corrections_dry_run(
+        ir_input_path=ir_path,
+        correctionset_manifest_path=manifest_path,
+        corrections_jsonl_path=corrections_path,
+        input_ir_version="ir_v1",
+        output_ir_path=out_ir,
+        output_report_path=out_report,
+        output_manifest_path=None,
+        generated_at="2026-05-16T15:01:00Z",
+    )
+
+    rows = _read_jsonl(out_ir)
+    assert rows[0]["fields_raw"]["senses"][0]["gloss_fr"] == "corrected:corr_20260516_000001"
+    assert rows[1]["fields_raw"]["senses"][0]["gloss_fr"] == "corrected:corr_20260516_000002"
+    assert result.summary["applied_in_dry_run"] == 2
+
+
+def test_same_record_conflict_detected(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+    record_hash = sha256_prefixed(ir_records[0])
+
+    a = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        record_sha256=record_hash,
+        patch=[{"op": "replace", "path": "/fields_raw/senses/0/gloss_fr", "value": "A"}],
+    )
+    b = _make_correction_record(
+        "corr_20260516_000002",
+        "ir_1",
+        record_sha256=record_hash,
+        patch=[{"op": "replace", "path": "/fields_raw/senses/0", "value": {"gloss_fr": "B"}}],
+    )
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [a, b])
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, _make_manifest(corrections_path))
+
+    out_ir = tmp_path / "out.jsonl"
+    out_report = tmp_path / "report.json"
+    result = run_corrections_dry_run(
+        ir_input_path=ir_path,
+        correctionset_manifest_path=manifest_path,
+        corrections_jsonl_path=corrections_path,
+        input_ir_version="ir_v1",
+        output_ir_path=out_ir,
+        output_report_path=out_report,
+        output_manifest_path=None,
+        generated_at="2026-05-16T15:01:00Z",
+    )
+    assert result.summary["conflicted"] == 2
+    assert result.summary["applied_in_dry_run"] == 0
+
+
+def test_same_record_array_shift_risk_conflict_detected(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_records[0]["fields_raw"]["senses"] = [
+        {"gloss_fr": "a"},
+        {"gloss_fr": "b"},
+    ]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+    record_hash = sha256_prefixed(ir_records[0])
+
+    a = _make_correction_record(
+        "corr_20260516_000003",
+        "ir_1",
+        record_sha256=record_hash,
+        patch=[{"op": "remove", "path": "/fields_raw/senses/0"}],
+    )
+    b = _make_correction_record(
+        "corr_20260516_000004",
+        "ir_1",
+        record_sha256=record_hash,
+        patch=[{"op": "replace", "path": "/fields_raw/senses/1/gloss_fr", "value": "changed"}],
+    )
+
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [a, b])
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, _make_manifest(corrections_path))
+
+    out_ir = tmp_path / "out.jsonl"
+    out_report = tmp_path / "report.json"
+    result = run_corrections_dry_run(
+        ir_input_path=ir_path,
+        correctionset_manifest_path=manifest_path,
+        corrections_jsonl_path=corrections_path,
+        input_ir_version="ir_v1",
+        output_ir_path=out_ir,
+        output_report_path=out_report,
+        output_manifest_path=None,
+        generated_at="2026-05-16T15:01:00Z",
+    )
+    assert result.summary["conflicted"] == 2
+    report = _read_json(out_report)
+    assert any(item["reason_code"] == "conflict_same_target_array_shift_risk" for item in report["corrections"])
+
+
+def test_hash_mismatch_rejected(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+
+    correction = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        record_sha256="sha256:not-the-real-hash",
+    )
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [correction])
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, _make_manifest(corrections_path))
+
+    out_ir = tmp_path / "out.jsonl"
+    out_report = tmp_path / "report.json"
+    result = run_corrections_dry_run(
+        ir_input_path=ir_path,
+        correctionset_manifest_path=manifest_path,
+        corrections_jsonl_path=corrections_path,
+        input_ir_version="ir_v1",
+        output_ir_path=out_ir,
+        output_report_path=out_report,
+        output_manifest_path=None,
+        generated_at="2026-05-16T15:01:00Z",
+    )
+    assert result.summary["applied_in_dry_run"] == 0
+    report = _read_json(out_report)
+    assert any(item["reason_code"] == "target_snapshot_hash_mismatch" for item in report["corrections"])
+
+
+def test_lifecycle_resolution_prevents_old_approved_apply(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+    record_hash = sha256_prefixed(ir_records[0])
+
+    older_approved = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        status="approved",
+        updated_at="2026-05-16T14:00:00Z",
+        record_sha256=record_hash,
+    )
+    newer_rejected = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        status="rejected",
+        updated_at="2026-05-16T15:00:00Z",
+        record_sha256=record_hash,
+    )
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [older_approved, newer_rejected])
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, _make_manifest(corrections_path))
+
+    out_ir = tmp_path / "out.jsonl"
+    out_report = tmp_path / "report.json"
+    result = run_corrections_dry_run(
+        ir_input_path=ir_path,
+        correctionset_manifest_path=manifest_path,
+        corrections_jsonl_path=corrections_path,
+        input_ir_version="ir_v1",
+        output_ir_path=out_ir,
+        output_report_path=out_report,
+        output_manifest_path=None,
+        generated_at="2026-05-16T15:01:00Z",
+    )
+    rows = _read_jsonl(out_ir)
+    assert rows[0]["fields_raw"]["senses"][0]["gloss_fr"] == "old"
+    assert result.summary["applied_in_dry_run"] == 0
+    report = _read_json(out_report)
+    assert any(item["reason_code"] == "non_latest_lifecycle_version" for item in report["corrections"])
+    assert any(item["reason_code"] == "not_approved_status" for item in report["corrections"])
+
+
+def test_deterministic_replay_byte_identical_with_fixed_metadata(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+    correction = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        record_sha256=sha256_prefixed(ir_records[0]),
+    )
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [correction])
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, _make_manifest(corrections_path))
+
+    out_ir_a = tmp_path / "out_a.jsonl"
+    out_report_a = tmp_path / "report_a.json"
+    out_ir_b = tmp_path / "out_b.jsonl"
+    out_report_b = tmp_path / "report_b.json"
+
+    kwargs = dict(
+        ir_input_path=ir_path,
+        correctionset_manifest_path=manifest_path,
+        corrections_jsonl_path=corrections_path,
+        input_ir_version="ir_v1",
+        output_manifest_path=None,
+        generated_at="2026-05-16T15:01:00Z",
+    )
+    run_corrections_dry_run(output_ir_path=out_ir_a, output_report_path=out_report_a, **kwargs)
+    run_corrections_dry_run(output_ir_path=out_ir_b, output_report_path=out_report_b, **kwargs)
+
+    assert out_ir_a.read_bytes() == out_ir_b.read_bytes()
+    assert out_report_a.read_bytes() == out_report_b.read_bytes()
+
+
+def test_global_ir_version_mismatch_is_fatal(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+    correction = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        record_sha256=sha256_prefixed(ir_records[0]),
+    )
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [correction])
+    manifest = _make_manifest(corrections_path)
+    manifest["target_ir_version"] = "ir_v2"
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(ValueError, match="fatal version mismatch"):
+        run_corrections_dry_run(
+            ir_input_path=ir_path,
+            correctionset_manifest_path=manifest_path,
+            corrections_jsonl_path=corrections_path,
+            input_ir_version="ir_v1",
+            output_ir_path=tmp_path / "out.jsonl",
+            output_report_path=tmp_path / "report.json",
+            output_manifest_path=None,
+            generated_at="2026-05-16T15:01:00Z",
+        )
+
+
+def test_latest_non_approved_is_skipped_with_reason(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+    record_hash = sha256_prefixed(ir_records[0])
+
+    approved_old = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        status="approved",
+        updated_at="2026-05-16T14:00:00Z",
+        record_sha256=record_hash,
+    )
+    withdrawn_new = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        status="withdrawn",
+        updated_at="2026-05-16T15:00:00Z",
+        record_sha256=record_hash,
+    )
+
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [approved_old, withdrawn_new])
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, _make_manifest(corrections_path))
+
+    out_ir = tmp_path / "out.jsonl"
+    out_report = tmp_path / "report.json"
+    result = run_corrections_dry_run(
+        ir_input_path=ir_path,
+        correctionset_manifest_path=manifest_path,
+        corrections_jsonl_path=corrections_path,
+        input_ir_version="ir_v1",
+        output_ir_path=out_ir,
+        output_report_path=out_report,
+        output_manifest_path=None,
+        generated_at="2026-05-16T15:01:00Z",
+    )
+    assert result.summary["applied_in_dry_run"] == 0
+    report = _read_json(out_report)
+    assert any(item["reason_code"] == "not_approved_status" for item in report["corrections"])
+
+
+def test_supersession_excludes_older_approved(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+    record_hash = sha256_prefixed(ir_records[0])
+
+    corr_a = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        status="approved",
+        updated_at="2026-05-16T14:00:00Z",
+        record_sha256=record_hash,
+    )
+    corr_b = _make_correction_record(
+        "corr_20260516_000002",
+        "ir_1",
+        status="approved",
+        updated_at="2026-05-16T15:00:00Z",
+        supersedes="corr_20260516_000001",
+        patch=[{"op": "replace", "path": "/fields_raw/senses/0/gloss_fr", "value": "from-b"}],
+        record_sha256=record_hash,
+    )
+
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [corr_a, corr_b])
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, _make_manifest(corrections_path))
+
+    out_ir = tmp_path / "out.jsonl"
+    out_report = tmp_path / "report.json"
+    result = run_corrections_dry_run(
+        ir_input_path=ir_path,
+        correctionset_manifest_path=manifest_path,
+        corrections_jsonl_path=corrections_path,
+        input_ir_version="ir_v1",
+        output_ir_path=out_ir,
+        output_report_path=out_report,
+        output_manifest_path=None,
+        generated_at="2026-05-16T15:01:00Z",
+    )
+    rows = _read_jsonl(out_ir)
+    assert rows[0]["fields_raw"]["senses"][0]["gloss_fr"] == "from-b"
+    assert result.summary["applied_in_dry_run"] == 1
+    report = _read_json(out_report)
+    assert any(item["reason_code"] == "superseded_by_newer_correction" for item in report["corrections"])
+
+
+def test_invalid_correctionset_manifest_schema_id_rejected(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+    correction = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        record_sha256=sha256_prefixed(ir_records[0]),
+    )
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [correction])
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, _make_manifest(corrections_path, schema_id="wrong_schema"))
+
+    with pytest.raises(ValueError, match="schema_id must be correctionset_manifest_v1"):
+        run_corrections_dry_run(
+            ir_input_path=ir_path,
+            correctionset_manifest_path=manifest_path,
+            corrections_jsonl_path=corrections_path,
+            input_ir_version="ir_v1",
+            output_ir_path=tmp_path / "out.jsonl",
+            output_report_path=tmp_path / "report.json",
+            output_manifest_path=None,
+            generated_at="2026-05-16T15:01:00Z",
+        )
+
+
+def test_corrections_jsonl_byte_length_mismatch_rejected(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+    correction = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        record_sha256=sha256_prefixed(ir_records[0]),
+    )
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [correction])
+    manifest = _make_manifest(corrections_path)
+    manifest["files"][0]["byte_length"] = manifest["files"][0]["byte_length"] + 1
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(ValueError, match="integrity mismatch"):
+        run_corrections_dry_run(
+            ir_input_path=ir_path,
+            correctionset_manifest_path=manifest_path,
+            corrections_jsonl_path=corrections_path,
+            input_ir_version="ir_v1",
+            output_ir_path=tmp_path / "out.jsonl",
+            output_report_path=tmp_path / "report.json",
+            output_manifest_path=None,
+            generated_at="2026-05-16T15:01:00Z",
+        )
+
+
+def test_corrections_jsonl_sha256_mismatch_rejected(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+    correction = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        record_sha256=sha256_prefixed(ir_records[0]),
+    )
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [correction])
+    manifest = _make_manifest(corrections_path)
+    manifest["files"][0]["sha256"] = "sha256:deadbeef"
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(ValueError, match="integrity mismatch"):
+        run_corrections_dry_run(
+            ir_input_path=ir_path,
+            correctionset_manifest_path=manifest_path,
+            corrections_jsonl_path=corrections_path,
+            input_ir_version="ir_v1",
+            output_ir_path=tmp_path / "out.jsonl",
+            output_report_path=tmp_path / "report.json",
+            output_manifest_path=None,
+            generated_at="2026-05-16T15:01:00Z",
+        )
+
+
+def test_invalid_patch_pointer_escape_tilde2_rejected(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+    correction = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        patch=[{"op": "replace", "path": "/fields_raw/senses/~2/gloss_fr", "value": "x"}],
+        record_sha256=sha256_prefixed(ir_records[0]),
+    )
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [correction])
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, _make_manifest(corrections_path))
+
+    run_corrections_dry_run(
+        ir_input_path=ir_path,
+        correctionset_manifest_path=manifest_path,
+        corrections_jsonl_path=corrections_path,
+        input_ir_version="ir_v1",
+        output_ir_path=tmp_path / "out.jsonl",
+        output_report_path=tmp_path / "report.json",
+        output_manifest_path=None,
+        generated_at="2026-05-16T15:01:00Z",
+    )
+    report = _read_json(tmp_path / "report.json")
+    assert any(item["reason_code"] == "invalid_patch_path" for item in report["corrections"])
+
+
+def test_invalid_patch_pointer_escape_trailing_tilde_rejected(tmp_path: Path):
+    ir_records = [_make_ir_record("ir_1", "old")]
+    ir_path = tmp_path / "ir.jsonl"
+    _write_jsonl(ir_path, ir_records)
+    correction = _make_correction_record(
+        "corr_20260516_000001",
+        "ir_1",
+        patch=[{"op": "replace", "path": "/fields_raw/senses/~", "value": "x"}],
+        record_sha256=sha256_prefixed(ir_records[0]),
+    )
+    corrections_path = tmp_path / "corrections.jsonl"
+    _write_jsonl(corrections_path, [correction])
+    manifest_path = tmp_path / "correctionset.manifest.json"
+    _write_json(manifest_path, _make_manifest(corrections_path))
+
+    run_corrections_dry_run(
+        ir_input_path=ir_path,
+        correctionset_manifest_path=manifest_path,
+        corrections_jsonl_path=corrections_path,
+        input_ir_version="ir_v1",
+        output_ir_path=tmp_path / "out.jsonl",
+        output_report_path=tmp_path / "report.json",
+        output_manifest_path=None,
+        generated_at="2026-05-16T15:01:00Z",
+    )
+    report = _read_json(tmp_path / "report.json")
+    assert any(item["reason_code"] == "invalid_patch_path" for item in report["corrections"])
+

--- a/api/corrections/validators.py
+++ b/api/corrections/validators.py
@@ -1,0 +1,309 @@
+"""Structural and semantic validators for correction records."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .helpers import parse_iso8601_utc, sha256_prefixed
+from .models import CorrectionRecord, Rejection
+from .patching import ALLOWED_PATCH_OPS, PatchError, apply_patch, parse_pointer
+
+ALLOWED_STATUSES = {
+    "draft",
+    "submitted",
+    "approved",
+    "rejected",
+    "withdrawn",
+    "superseded",
+    "applied",
+}
+
+REQUIRED_TOP_LEVEL_FIELDS = {
+    "schema_id",
+    "schema_version",
+    "correction_id",
+    "target_ir_id",
+    "patch",
+    "submitter",
+    "timestamps",
+    "status",
+    "provenance",
+}
+
+ALLOWED_SUBMITTED_VIA = {"manual_import", "api", "batch"}
+CORRECTION_ID_RE = re.compile(r"^corr_[0-9]{8}_[0-9]{6}$")
+ANON_TOKEN_RE = re.compile(r"^anon_[a-z0-9]{16,64}$")
+
+
+def _reject(record: CorrectionRecord, reason_code: str, detail: str | None = None) -> Rejection:
+    return Rejection(
+        correction_id=record.correction_id,
+        target_ir_id=record.target_ir_id,
+        reason_code=reason_code,
+        detail=detail,
+    )
+
+
+def _validate_timestamp(value: Any, field_name: str, allow_null: bool) -> str | None:
+    if value is None and allow_null:
+        return None
+    if not isinstance(value, str):
+        return f"{field_name} must be an ISO-8601 UTC string"
+    try:
+        parse_iso8601_utc(value)
+    except ValueError as exc:
+        return f"{field_name} invalid: {exc}"
+    return None
+
+
+def validate_structural(record: CorrectionRecord) -> list[Rejection]:
+    raw = record.raw
+    errors: list[Rejection] = []
+    missing = sorted(REQUIRED_TOP_LEVEL_FIELDS - set(raw.keys()))
+    if missing:
+        errors.append(_reject(record, "invalid_structural", f"missing fields: {', '.join(missing)}"))
+        return errors
+
+    unknown = sorted(set(raw.keys()) - REQUIRED_TOP_LEVEL_FIELDS)
+    if unknown:
+        errors.append(_reject(record, "invalid_structural", f"unknown fields: {', '.join(unknown)}"))
+
+    if raw.get("schema_id") != "correction_record_v1":
+        errors.append(_reject(record, "invalid_structural", "schema_id must be correction_record_v1"))
+    if raw.get("schema_version") != 1:
+        errors.append(_reject(record, "invalid_structural", "schema_version must be 1"))
+
+    correction_id = raw.get("correction_id")
+    if not isinstance(correction_id, str) or not correction_id:
+        errors.append(_reject(record, "invalid_structural", "correction_id must be non-empty string"))
+    elif CORRECTION_ID_RE.fullmatch(correction_id) is None:
+        errors.append(_reject(record, "invalid_structural", "correction_id must match ^corr_[0-9]{8}_[0-9]{6}$"))
+    target_ir_id = raw.get("target_ir_id")
+    if not isinstance(target_ir_id, str) or not target_ir_id:
+        errors.append(_reject(record, "invalid_structural", "target_ir_id must be non-empty string"))
+
+    submitter = raw.get("submitter")
+    if not isinstance(submitter, dict):
+        errors.append(_reject(record, "invalid_structural", "submitter must be object"))
+    else:
+        token = submitter.get("anonymous_token")
+        if not isinstance(token, str) or not token:
+            errors.append(_reject(record, "invalid_structural", "submitter.anonymous_token is required"))
+        elif ANON_TOKEN_RE.fullmatch(token) is None:
+            errors.append(
+                _reject(
+                    record,
+                    "invalid_structural",
+                    "submitter.anonymous_token must match ^anon_[a-z0-9]{16,64}$",
+                )
+            )
+
+    status = raw.get("status")
+    if status not in ALLOWED_STATUSES:
+        errors.append(_reject(record, "invalid_structural", f"invalid status: {status!r}"))
+
+    timestamps = raw.get("timestamps")
+    if not isinstance(timestamps, dict):
+        errors.append(_reject(record, "invalid_structural", "timestamps must be object"))
+    else:
+        required_ts = [
+            "created_at",
+            "updated_at",
+            "submitted_at",
+            "reviewed_at",
+            "decided_at",
+            "applied_at",
+        ]
+        missing_ts = [key for key in required_ts if key not in timestamps]
+        if missing_ts:
+            errors.append(_reject(record, "invalid_structural", f"missing timestamps: {', '.join(missing_ts)}"))
+        else:
+            for key in ("created_at", "updated_at"):
+                err = _validate_timestamp(timestamps.get(key), key, allow_null=False)
+                if err:
+                    errors.append(_reject(record, "invalid_structural", err))
+            for key in ("submitted_at", "reviewed_at", "decided_at", "applied_at"):
+                err = _validate_timestamp(timestamps.get(key), key, allow_null=True)
+                if err:
+                    errors.append(_reject(record, "invalid_structural", err))
+            status_errors = validate_status_timestamp_consistency(status, timestamps)
+            errors.extend(_reject(record, "invalid_structural", err) for err in status_errors)
+
+    patch = raw.get("patch")
+    if not isinstance(patch, list) or not patch:
+        errors.append(_reject(record, "invalid_structural", "patch must be non-empty array"))
+    else:
+        for idx, op in enumerate(patch):
+            if not isinstance(op, dict):
+                errors.append(_reject(record, "invalid_structural", f"patch[{idx}] must be object"))
+                continue
+            op_name = op.get("op")
+            if op_name not in ALLOWED_PATCH_OPS:
+                errors.append(_reject(record, "invalid_structural", f"patch[{idx}] invalid op {op_name!r}"))
+            path = op.get("path")
+            if not isinstance(path, str):
+                errors.append(_reject(record, "invalid_patch_path", f"patch[{idx}] path must be string"))
+                continue
+            if not path.startswith("/fields_raw/"):
+                errors.append(
+                    _reject(record, "invalid_patch_path", f"patch[{idx}] path must be under /fields_raw/...")
+                )
+            try:
+                parse_pointer(path)
+            except PatchError as exc:
+                errors.append(_reject(record, "invalid_patch_path", f"patch[{idx}] invalid JSON pointer: {exc}"))
+            if op_name in {"add", "replace"} and "value" not in op:
+                errors.append(_reject(record, "invalid_structural", f"patch[{idx}] requires value"))
+            if op_name == "remove" and "value" in op:
+                errors.append(_reject(record, "invalid_structural", f"patch[{idx}] remove cannot include value"))
+
+    provenance = raw.get("provenance")
+    if not isinstance(provenance, dict):
+        errors.append(_reject(record, "invalid_structural", "provenance must be object"))
+    else:
+        reason = provenance.get("reason")
+        if not isinstance(reason, str) or not reason:
+            errors.append(_reject(record, "invalid_structural", "provenance.reason is required string"))
+        evidence_refs = provenance.get("evidence_refs")
+        if evidence_refs is not None:
+            if not isinstance(evidence_refs, list) or any(not isinstance(item, str) for item in evidence_refs):
+                errors.append(
+                    _reject(record, "invalid_structural", "provenance.evidence_refs must be list[str] when present")
+                )
+
+        target_snapshot = provenance.get("target_snapshot")
+        if not isinstance(target_snapshot, dict):
+            errors.append(_reject(record, "invalid_structural", "provenance.target_snapshot is required"))
+        else:
+            ir_version = target_snapshot.get("ir_version")
+            if not isinstance(ir_version, str) or not ir_version:
+                errors.append(
+                    _reject(record, "invalid_structural", "provenance.target_snapshot.ir_version required")
+                )
+            if status in {"approved", "applied"} and not target_snapshot.get("record_sha256"):
+                errors.append(
+                    _reject(
+                        record,
+                        "invalid_structural",
+                        "approved/applied corrections require provenance.target_snapshot.record_sha256",
+                    )
+                )
+        audit = provenance.get("audit")
+        if not isinstance(audit, dict):
+            errors.append(_reject(record, "invalid_structural", "provenance.audit is required object"))
+        else:
+            submitted_via = audit.get("submitted_via")
+            if submitted_via not in ALLOWED_SUBMITTED_VIA:
+                errors.append(
+                    _reject(
+                        record,
+                        "invalid_structural",
+                        "provenance.audit.submitted_via must be one of: manual_import | api | batch",
+                    )
+                )
+            for field_name in ("reviewer_token", "decision_note", "supersedes_correction_id"):
+                value = audit.get(field_name)
+                if value is not None and not isinstance(value, str):
+                    errors.append(
+                        _reject(
+                            record,
+                            "invalid_structural",
+                            f"provenance.audit.{field_name} must be string or null",
+                        )
+                    )
+
+    return errors
+
+
+def validate_status_timestamp_consistency(status: str, timestamps: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    submitted_at = timestamps.get("submitted_at")
+    reviewed_at = timestamps.get("reviewed_at")
+    decided_at = timestamps.get("decided_at")
+    applied_at = timestamps.get("applied_at")
+
+    if status != "draft" and submitted_at is None:
+        errors.append(f"{status} requires submitted_at")
+
+    decision_statuses = {"approved", "rejected", "withdrawn", "superseded", "applied"}
+    if status in decision_statuses:
+        if reviewed_at is None:
+            errors.append(f"{status} requires reviewed_at")
+        if decided_at is None:
+            errors.append(f"{status} requires decided_at")
+
+    if status == "applied":
+        if applied_at is None:
+            errors.append("applied requires applied_at")
+    elif applied_at is not None:
+        errors.append(f"{status} must not set applied_at")
+
+    return errors
+
+
+def validate_semantic(
+    record: CorrectionRecord,
+    target_record: dict[str, Any] | None,
+    correctionset_target_version: str,
+) -> list[Rejection]:
+    rejections: list[Rejection] = []
+    if target_record is None:
+        return [_reject(record, "target_ir_id_not_found", "target_ir_id missing from input IR")]
+
+    target_snapshot = (
+        record.raw.get("provenance", {}).get("target_snapshot", {})
+        if isinstance(record.raw.get("provenance", {}), dict)
+        else {}
+    )
+    record_ir_version = target_snapshot.get("ir_version")
+    if record_ir_version != correctionset_target_version:
+        rejections.append(
+            _reject(
+                record,
+                "target_snapshot_version_mismatch",
+                "record target snapshot version does not match correctionset target version",
+            )
+        )
+
+    if record.status == "approved":
+        expected_hash = target_snapshot.get("record_sha256")
+        actual_hash = sha256_prefixed(target_record)
+        if expected_hash != actual_hash:
+            rejections.append(
+                _reject(
+                    record,
+                    "target_snapshot_hash_mismatch",
+                    "record_sha256 does not match target IR record hash",
+                )
+            )
+
+    return rejections
+
+
+def preflight_patch(record: CorrectionRecord, target_record: dict[str, Any]) -> list[Rejection]:
+    try:
+        patched = apply_patch(target_record, record.patch)
+    except PatchError as exc:
+        return [_reject(record, "patch_apply_failed", str(exc))]
+
+    shape_error = validate_ir_shape(target_record, patched)
+    if shape_error:
+        return [_reject(record, "post_patch_ir_invalid", shape_error)]
+    return []
+
+
+def validate_ir_shape(original: dict[str, Any], patched: dict[str, Any]) -> str | None:
+    required_fields = ["ir_id", "ir_kind", "source_id", "fields_raw"]
+    for key in required_fields:
+        if key not in patched:
+            return f"patched record missing required field: {key}"
+
+    if not isinstance(patched.get("fields_raw"), dict):
+        return "patched fields_raw must remain an object"
+
+    for immutable in ("ir_id", "ir_kind", "source_id"):
+        if patched.get(immutable) != original.get(immutable):
+            return f"patched record changed immutable field: {immutable}"
+    return None
+

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -23,6 +23,7 @@ siralex-parse-ir = "ir_parser.cli:main"
 siralex-build-index = "search_index.cli:main"
 siralex-build-bundle = "bundle_builder.cli:main"
 siralex-enrich = "enrichment.cli:main"
+siralex-corrections-dry-run = "corrections.cli:main"
 
 [tool.ruff]
 line-length = 100
@@ -32,7 +33,7 @@ target-version = "py310"
 select = ["E", "F", "I", "W"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["snapshot_engine", "ir_parser", "search_index", "bundle_builder", "enrichment"]
+packages = ["snapshot_engine", "ir_parser", "search_index", "bundle_builder", "enrichment", "corrections"]
 
 [build-system]
 requires = ["hatchling"]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -176,7 +176,7 @@ DoD:
 
 Parts of the feedback loop can be built without a UI. This work is safe and doesn't lock UX decisions.
 
-#### 1. Correction record schema (spec-level)
+#### 1.5A — Correction record schema/specification ✅ *(complete)*
 
 JSON schema for:
 
@@ -187,9 +187,21 @@ JSON schema for:
 - `timestamps`
 - `status`
 
-This is already hinted at in multiple specs — formalizing it completes the data model loop.
+Formal specification has now been drafted:
 
-#### 2. Correction application pipeline (dry-run)
+- Spec: `shared/specs/correction-record-schema-v1.md`
+- Scope includes:
+  - exact schema fields
+  - allowed correction statuses
+  - `target_ir_id` relationship to IR
+  - RFC 6902 patch constraints
+  - validation rules
+  - provenance/audit metadata
+  - test requirements for validation behavior
+
+This milestone is schema-only and does not change runtime behavior.
+
+#### 1.5B — Correction application pipeline (dry-run) ✅ *(complete)*
 
 Tool that:
 
@@ -199,9 +211,37 @@ Tool that:
 
 No UI, no moderation yet — just correctness.
 
+Planning/specification artifact drafted:
+
+- Spec: `shared/specs/correction-application-dry-run.md`
+- Scope includes:
+  - correctionset input format and deterministic ordering
+  - input contracts and IR version context
+  - validation stages and approved-status filtering
+  - conflict policy and deterministic apply/reject behavior
+  - apply-on-copy behavior and output artifact contract
+  - failure reason codes and deterministic test matrix
+
+Implementation completion note:
+
+- correctionset manifest contract validation + `corrections.jsonl` integrity checks (`byte_length` + `sha256`)
+- lifecycle resolution, supersession filtering, and same-target conflict handling
+- deterministic apply-on-copy corrected IR output + machine-readable report generation
+- CLI command: `siralex-corrections-dry-run`
+- focused backend test coverage for lifecycle, integrity, conflicts, patch validation, and deterministic replay
+
+Current boundaries (still intentional):
+
+- correction schema/spec is complete
+- dry-run apply pipeline is complete
+- no UI/moderation workflow exists yet
+- no committed correction-release workflow exists yet
+- dry-run does not persist lifecycle transitions to `applied`
+
 DoD:
-- Correction record JSON schema formalized in `shared/specs/`.
-- Dry-run pipeline can apply corrections to IR and produce a new versioned output.
+- Correction record schema/specification is formalized in `shared/specs/correction-record-schema-v1.md`.
+- Dry-run pipeline specification is formalized in `shared/specs/correction-application-dry-run.md`.
+- Dry-run pipeline implementation is complete with deterministic dry-run outputs and report generation.
 
 ---
 
@@ -245,12 +285,13 @@ DoD:
 | 11 | Phase 3.4 — Multi-bundle support | Platform generalization | ✅ Complete |
 | 12 | Phase 3.5 — Bundle selection + distribution | Platform generalization | ✅ Complete |
 | 13 | Phase 5a — `norm_v2` indexing shipped | Search/index quality | ✅ Complete |
-| 14 | Phase 5b — Field Validation + Search Reality Calibration | Next primary focus | Pending |
-| 15 | Phase 1.5 (spec + backend) — Correction schema + pipeline | Parallel, light | Pending |
-| 16 | HTTPS + device validation execution | Active validation track | Pending |
-| 17 | Branch C — Transliteration, morphology, linguistic inference | Only after users + data | Deferred |
+| 14 | Phase 5b — Field Validation + Search Reality Calibration | Validation track | Substantially complete (Android real-device validation deferred pending hardware access) |
+| 15 | Phase 1.5A — Correction record schema/specification | Next formal engineering milestone | ✅ Complete |
+| 16 | Phase 1.5B — Dry-run correction application pipeline | Follows 1.5A approval | ✅ Complete |
+| 17 | HTTPS + Android validation execution | Active validation follow-up | Pending hardware access |
+| 18 | Branch C — Transliteration, morphology, linguistic inference | Only after users + data | Deferred |
 
-Phase 2.0 (Branch A) and the originally planned Phase 3 platform work have now served their purpose: the runtime proves bundle ingestion, IndexedDB storage, query execution, rendering, offline shell behavior, manifest-driven language metadata, installed bundle registry, active bundle selection, multi-bundle isolation, and catalog-driven install/update flows. The roadmap was previously lagging behind this implementation reality. Search/index quality is no longer a single undifferentiated pending bucket: **Phase 5a** is now treated as complete because `norm_v2` indexing has been implemented and validated, while **Phase 5b** becomes the next primary engineering track for observing real search behavior under real constraints and calibrating future bundle improvements against empirical usage. Directional contract hardening remains necessary, but it is now a bounded subtask inside that validation phase rather than the phase objective. Phase 1.5 backend work can still proceed in parallel as light spec work, and device/deployment validation is elevated into active execution during Phase 5b. Branch C remains explicitly deferred until real usage data exists.
+Phase 2.0 (Branch A) and the originally planned Phase 3 platform work have now served their purpose: the runtime proves bundle ingestion, IndexedDB storage, query execution, rendering, offline shell behavior, manifest-driven language metadata, installed bundle registry, active bundle selection, multi-bundle isolation, and catalog-driven install/update flows. The roadmap was previously lagging behind this implementation reality. Search/index quality is no longer a single undifferentiated pending bucket: **Phase 5a** is now treated as complete because `norm_v2` indexing has been implemented and validated, while **Phase 5b** is now substantially complete with Android real-device validation explicitly deferred until hardware access resumes. With that transition, **Phase 1.5A** (correction record schema/specification) and **Phase 1.5B** (dry-run correction application pipeline) are complete for backend dry-run scope. UI/moderation workflows and committed correction-release lifecycle persistence remain intentionally out of scope for this completion state. Branch C remains explicitly deferred until real usage data exists.
 
 The completed Phase 2.0 work followed clean layer separation:
 

--- a/shared/specs/correction-application-dry-run.md
+++ b/shared/specs/correction-application-dry-run.md
@@ -1,0 +1,326 @@
+# Correction application dry-run pipeline plan/spec (Phase 1.5B)
+
+This document defines the implementation plan and normative contracts for Phase 1.5B.
+
+Scope is planning/specification only. No runtime code is introduced by this document.
+
+## Objectives
+
+- Apply approved corrections to an immutable IR snapshot in dry-run mode.
+- Produce deterministic, auditable outputs.
+- Never mutate frozen historical datasets in place.
+
+## Non-goals (Phase 1.5B)
+
+- No UI/moderation workflow implementation
+- No automatic lifecycle persistence to `applied`
+- No changes to normalization, search, or bundle generation behavior
+
+---
+
+## 1) Correctionset input format
+
+### Decision
+
+Use a correctionset wrapper plus JSONL payload:
+
+- `correctionset.manifest.json` (metadata, version context, integrity)
+- `corrections.jsonl` (one `correction_record_v1` per line)
+
+### Why not raw JSONL alone
+
+Raw JSONL alone is insufficient for explicit dataset/version anchoring and deterministic correctionset identity. The wrapper provides version context and integrity without changing per-record schema.
+
+### Proposed correctionset manifest fields
+
+- `correctionset_id` (stable identifier)
+- `correctionset_version` (monotonic integer or semver-like string)
+- `schema_id` (`correctionset_manifest_v1`)
+- `created_at` (ISO-8601 UTC)
+- `target_ir_version` (must match pipeline input IR context)
+- `files[]` with `{ path, sha256, byte_length }`
+- `content_sha256` (canonical hash over `files[]`)
+
+Implementation note (explicit deferral):
+
+- Phase 1.5B implementation SHOULD validate manifest schema/required fields and `corrections.jsonl` file integrity (`byte_length` + `sha256`) immediately.
+- Full `content_sha256` canonicalization verification may remain deferred only by deliberate design, and must be documented when deferred.
+
+### Deterministic ordering rules
+
+After lifecycle resolution (see validation/application sections), pipeline computes a single deterministic apply order:
+
+1. `target_ir_id` ascending (bytewise string order)
+2. `timestamps.submitted_at` ascending (nulls last)
+3. `correction_id` ascending
+4. original file line number ascending (final tiebreaker)
+
+The same inputs must always produce the same apply order.
+
+### Correctionset completeness and lifecycle scope (normative)
+
+Phase 1.5B dry-run resolves lifecycle state only from correction records contained in the supplied correctionset inputs.
+
+Normative expectations:
+
+- A correctionset intended for dry-run application MUST be assembled as a self-contained eligibility snapshot.
+- It MUST include the latest known lifecycle record for every `correction_id` intended to be considered.
+- The dry-run pipeline MUST NOT consult external correctionset history outside supplied inputs.
+
+---
+
+## 2) Pipeline input contracts
+
+Required inputs:
+
+- Immutable IR snapshot JSONL (input file, read-only)
+- Correctionset (`correctionset.manifest.json` + `corrections.jsonl`)
+- Explicit IR version context (CLI arg or config), expected to match:
+  - IR artifact version in execution context
+  - correctionset `target_ir_version`
+  - each correction record `provenance.target_snapshot.ir_version`
+
+Contract rules:
+
+- Input IR file is never modified.
+- If pipeline input IR version context does not equal `correctionset.manifest.target_ir_version`, the run fails fatally before per-record processing.
+- Per-record `provenance.target_snapshot.ir_version` must be evaluated against correctionset target version during semantic validation.
+
+---
+
+## 3) Validation stages
+
+Validation executes as a strict pipeline:
+
+1. **Correction record structural validation**
+   - validate `correction_record_v1` required fields/types/enums
+2. **Latest lifecycle resolution per `correction_id`**
+   - load all correction records first
+   - choose exactly one latest lifecycle record per `correction_id`
+   - primary key: `timestamps.updated_at` descending (latest wins)
+   - deterministic tie-breakers (single supplied correctionset mode): source file line number descending, then canonical JSON string order
+   - `correctionset_version` is manifest-level/shared in single-correctionset mode and is therefore non-operative for per-row tie-breaking (reserved for future multi-correctionset ingestion mode)
+   - non-latest lifecycle records are excluded from eligibility with reason `non_latest_lifecycle_version`
+3. **Approved-status filtering (after lifecycle resolution)**
+   - only latest records with `status = approved` progress
+   - latest records with non-approved statuses are skipped with reason `not_approved_status`
+4. **Semantic validation against target IR snapshot**
+   - `target_ir_id` exists
+   - per-record `provenance.target_snapshot.ir_version` must match correctionset target version
+5. **`record_sha256` match enforcement**
+   - for approved records, `provenance.target_snapshot.record_sha256` required
+   - compute pre-patch target record hash and compare
+6. **Supersession exclusion (before conflict grouping)**
+   - if approved correction `B` declares `provenance.audit.supersedes_correction_id = A`, then `A` is excluded/rejected with `superseded_by_newer_correction`
+   - supersession is evaluated only among lifecycle-resolved, approved candidates
+7. **Patch preflight**
+   - ops allowed in v1 (`add|remove|replace`)
+   - path under `/fields_raw/...` only
+   - patch can be applied cleanly to target JSON
+   - post-patch IR shape validates
+
+Any failed stage yields deterministic rejection reason(s) and no mutation.
+
+---
+
+## 4) Conflict policy
+
+Conflicts are evaluated after approved filtering and before final apply.
+
+### A) Multiple approved corrections on same `target_ir_id`
+
+- Group by `target_ir_id`.
+- If only one eligible record in group: apply candidate.
+- If multiple eligible records, evaluate cross-correction conflicts below.
+
+### B) Overlapping JSON Pointer paths
+
+Two eligible corrections for same target conflict if any operation path is:
+
+- exact same path, or
+- ancestor/descendant path (e.g. `/fields_raw/senses/0` vs `/fields_raw/senses/0/gloss_fr`)
+
+Conflict outcome policy (v1):
+
+- reject all conflicting corrections for that target record in this run (`conflicted`)
+- do not attempt partial merge or heuristic ordering fixes
+
+### C) Array index shift safety (conservative v1 rule)
+
+For multiple eligible corrections targeting the same `target_ir_id`, if any correction contains `add` or `remove` on an array-indexed path that could shift element positions, the entire same-target candidate group is treated as conflicted in v1.
+
+Examples of shift-risk operations include paths like:
+
+- `/fields_raw/senses/0`
+- `/fields_raw/examples/2/translations/1`
+
+Normative rule:
+
+- Single corrections that use `add`/`remove` remain allowed.
+- Multi-correction same-target groups with potential array index shift risk are rejected as `conflicted` (reason `conflict_same_target_array_shift_risk`) rather than merged.
+- v1 prioritizes deterministic safety over permissive same-record merging.
+
+### D) Superseded corrections
+
+- If status is `superseded`, never eligible.
+- If approved correction `B` declares `provenance.audit.supersedes_correction_id = A`:
+  - supersession is processed after latest lifecycle resolution and approved filtering
+  - `A` is excluded/rejected with reason `superseded_by_newer_correction` before conflict grouping
+  - `B` remains candidate unless rejected by later validation or conflict rules
+
+### E) Deterministic apply/reject behavior
+
+- Same input files + same IR snapshot => identical classification and output bytes.
+- No nondeterministic dependency on hash maps or runtime iteration order.
+
+---
+
+## 5) Application behavior
+
+Normative behavior:
+
+- Apply-on-copy only:
+  - read each IR record
+  - if no eligible correction, write record unchanged
+  - if eligible correction, apply patch to in-memory copy and write patched record
+- Never mutate source IR file in place.
+- Preserve deterministic output record ordering:
+  - keep original IR JSONL record order unchanged
+
+### Corrected IR output naming/versioning concept
+
+Recommended output naming:
+
+- `data/ir/{base_ir_version}__corrdryrun_{correctionset_id}_v{correctionset_version}.jsonl`
+
+Recommended companion metadata:
+
+- `corrected_ir_manifest.json` with:
+  - `base_ir_version`
+  - `correctionset_id`
+  - `correctionset_version`
+  - `dry_run: true`
+  - `generated_at`
+  - `input/output sha256`
+
+Determinism rule for metadata timestamps:
+
+- `generated_at` (and any run timestamp fields in reports/manifests) must support deterministic injection via CLI/config.
+- Byte-identical replay guarantees assume deterministic metadata inputs are fixed (including injected timestamps).
+
+---
+
+## 6) Output artifacts
+
+Phase 1.5B dry-run should emit:
+
+1. **Corrected IR JSONL**
+   - full IR output with approved, valid, non-conflicted corrections applied on copy
+2. **Machine-readable application report** (`correction_application_report.json`)
+   - per-correction disposition and reason codes
+   - run metadata and integrity hashes
+3. **Summary counts**
+   - `eligible`
+   - `applied_in_dry_run`
+   - `rejected`
+   - `conflicted`
+   - optional supporting counts: `skipped_non_approved`, `invalid_structural`, `invalid_semantic`
+
+---
+
+## 7) Failure handling
+
+Required reason codes (minimum set):
+
+- `target_ir_id_not_found`
+- `target_snapshot_version_mismatch`
+- `target_snapshot_hash_mismatch`
+- `invalid_patch_path`
+- `patch_apply_failed`
+- `post_patch_ir_invalid`
+- `not_approved_status`
+- `conflict_same_target_overlapping_paths`
+- `conflict_same_target_array_shift_risk`
+- `superseded_by_newer_correction`
+- `non_latest_lifecycle_version`
+
+Failure behavior rules:
+
+- Failure of one correction must not abort unrelated corrections by default.
+- Global manifest/input corruption may abort run early with explicit fatal error.
+- Every rejected/conflicted correction must include a machine-readable reason code.
+- Global IR version context mismatch (`input IR version != correctionset target version`) is a fatal run error.
+
+---
+
+## 8) Tests
+
+Minimum Phase 1.5B test matrix:
+
+1. **Valid single correction**
+   - one approved correction applies cleanly
+2. **Multiple independent corrections**
+   - different target records all apply
+3. **Same-record conflict**
+   - overlapping paths become `conflicted` and are not applied
+4. **Hash mismatch**
+   - approved correction with mismatched `record_sha256` rejected
+5. **Non-approved skipped**
+   - submitted/rejected/etc. are skipped with reason code
+6. **Deterministic replay**
+   - identical inputs produce byte-identical corrected IR + report outputs
+
+Recommended extras:
+
+- supersession handling
+- invalid pointer/index patch failures
+- post-patch schema invalidation
+
+---
+
+## 9) Exact files/modules likely to be created or changed
+
+Planned backend modules:
+
+- `api/corrections/models.py`
+  - correction/correctionset typed models
+- `api/corrections/loaders.py`
+  - load + parse manifest and JSONL records
+- `api/corrections/validators.py`
+  - structural + semantic validation stages
+- `api/corrections/conflicts.py`
+  - same-target grouping and path-overlap conflict detection
+- `api/corrections/dry_run_apply.py`
+  - apply-on-copy engine + deterministic ordering
+- `api/corrections/reporting.py`
+  - machine-readable report generation
+
+CLI entrypoints:
+
+- `api/cli/corrections_dry_run.py` (or equivalent command wiring)
+- command name proposal: `siralex-corrections-dry-run`
+
+Tests:
+
+- `tests/corrections/test_models.py`
+- `tests/corrections/test_validators.py`
+- `tests/corrections/test_conflicts.py`
+- `tests/corrections/test_dry_run_apply.py`
+- `tests/corrections/test_determinism.py`
+
+Spec/docs updates:
+
+- `shared/specs/correction-record-schema-v1.md` (cross-reference only, if needed)
+- `docs/ROADMAP.md` (phase status and linkage)
+
+---
+
+## Dry-run lifecycle boundary
+
+Phase 1.5B dry-run does not persist lifecycle transitions to `applied` by default.
+Any status transition persistence belongs to a separate committed correction release workflow and must be explicitly specified in a later phase.
+
+## Hashing determinism note
+
+`content_sha256` canonicalization details for correctionset/report artifacts must be explicitly defined during implementation so hashing is deterministic across environments.
+This planning pass intentionally defers full canonicalization algorithm details.

--- a/shared/specs/correction-record-schema-v1.md
+++ b/shared/specs/correction-record-schema-v1.md
@@ -1,0 +1,275 @@
+# Correction record schema/specification (v1)
+
+This spec defines the correction record contract for SiraLex Phase 1.5A.
+
+Purpose:
+
+- represent proposed/approved corrections to existing IR records
+- keep frozen historical datasets immutable
+- enable a later deterministic dry-run correction application pipeline
+
+This is a schema/specification document only. It does not define UI, moderation workflow implementation, or correction application runtime behavior.
+
+## Goals
+
+- Define a stable correction record schema (`correction_record_v1`).
+- Make correction payloads auditable and reproducible.
+- Constrain RFC 6902 patches so they are safe and deterministic.
+- Ensure correction application can produce new IR versions without in-place mutation.
+
+## Non-goals
+
+- Building submission UI
+- Building reviewer/moderation UI
+- Applying corrections in runtime pipelines (Phase 1.5B)
+- Changing current IR, normalization, search, or bundle generation behavior
+
+## Schema identity
+
+- `schema_id`: `correction_record_v1`
+- `schema_version`: `1`
+
+Correction records are line-delimited JSON objects (`.jsonl`) in future correctionset artifacts. Each line is one correction record.
+
+## Exact schema fields
+
+Each correction record MUST be a JSON object with the following top-level fields:
+
+- `schema_id` (string, required; MUST be `correction_record_v1`)
+- `schema_version` (integer, required; MUST be `1`)
+- `correction_id` (string, required)
+- `target_ir_id` (string, required)
+- `patch` (array of RFC 6902 operation objects, required)
+- `submitter` (object, required)
+- `timestamps` (object, required)
+- `status` (string enum, required)
+- `provenance` (object, required)
+
+Recommended full structure:
+
+```json
+{
+  "schema_id": "correction_record_v1",
+  "schema_version": 1,
+  "correction_id": "corr_20260516_000001",
+  "target_ir_id": "964909ef6912ff64",
+  "patch": [
+    {
+      "op": "replace",
+      "path": "/fields_raw/senses/0/gloss_fr",
+      "value": "gloss corrected example"
+    }
+  ],
+  "submitter": {
+    "anonymous_token": "anon_6f5f2f85d0dc4a0d"
+  },
+  "timestamps": {
+    "created_at": "2026-05-16T10:40:00Z",
+    "updated_at": "2026-05-16T10:40:00Z",
+    "submitted_at": "2026-05-16T10:40:00Z",
+    "reviewed_at": null,
+    "decided_at": null,
+    "applied_at": null
+  },
+  "status": "submitted",
+  "provenance": {
+    "reason": "Typo in French gloss",
+    "evidence_refs": [
+      "https://example.invalid/reference"
+    ],
+    "target_snapshot": {
+      "ir_version": "malipense_lexicon_v3",
+      "record_sha256": "sha256:7c0db4..."
+    },
+    "audit": {
+      "submitted_via": "manual_import",
+      "reviewer_token": null,
+      "decision_note": null,
+      "supersedes_correction_id": null
+    }
+  }
+}
+```
+
+## Allowed correction statuses
+
+`status` MUST be one of:
+
+- `draft`
+- `submitted`
+- `approved`
+- `rejected`
+- `withdrawn`
+- `superseded`
+- `applied`
+
+Normative status constraints:
+
+- `draft` records are not eligible for application.
+- Only `approved` is eligible for application in Phase 1.5B dry-run.
+- `applied` is not set by Phase 1.5B dry-run tooling by default; it belongs to a later committed application/release workflow unless explicitly designed and approved otherwise.
+- `rejected`, `withdrawn`, and `superseded` are terminal non-applicable statuses.
+
+## Correction identity across correctionset versions
+
+`correction_id` is the stable identity of one logical correction and MUST remain unchanged across correctionset versions that represent lifecycle/status updates for that same correction.
+
+Normative rule:
+
+- Lifecycle updates (for example `submitted -> approved`) produce a new correction record version in a newer correctionset, reusing the same `correction_id`.
+- `correction_id` MUST NOT be reused for unrelated corrections.
+
+## `target_ir_id` relationship to IR records
+
+`target_ir_id` MUST reference an existing IR record `ir_id` in the selected input IR dataset/version used during validation/apply.
+
+Normative rules:
+
+- Exactly one correction targets exactly one IR record.
+- `target_ir_id` must be resolved by exact string match to `ir_id`.
+- If no matching IR record exists, correction is invalid for that input dataset.
+- A correction is evaluated against the specific IR snapshot declared in `provenance.target_snapshot.ir_version`.
+- Correction application MUST produce a new IR artifact version; it MUST NOT mutate the original source JSONL in place.
+
+## RFC 6902 patch constraints
+
+The `patch` field MUST be a non-empty array of RFC 6902 operations.
+
+Allowed operations:
+
+- `add`
+- `remove`
+- `replace`
+
+Disallowed operations in v1:
+
+- `move`
+- `copy`
+- `test`
+
+Path constraints:
+
+- `path` MUST be under `/fields_raw/...` and MUST NOT equal `/fields_raw` itself in v1.
+- Patches MUST NOT modify immutable identity/provenance fields, including:
+  - `/ir_id`
+  - `/ir_kind`
+  - `/source_id`
+  - `/provenance`
+  - `/norm_version`
+- `path` must be valid JSON Pointer (RFC 6901) syntax.
+
+Operation constraints:
+
+- `add` and `replace` MUST include `value`.
+- `remove` MUST NOT include `value`.
+- The full patch sequence must be deterministic when applied in order.
+
+## Validation rules
+
+Validation should run in two levels: schema validation then semantic validation.
+
+Validation context is split explicitly:
+
+- Standalone record validation (this phase) validates the record in isolation.
+- Full lifecycle transition validation requires prior correctionset/version history and belongs to correction workflow logic (later phase), not isolated record validation.
+
+### A) Structural/schema validation
+
+- Required top-level fields must exist.
+- No top-level unknown fields unless explicitly allowed by schema extension policy.
+- `correction_id` format: `^corr_[0-9]{8}_[0-9]{6}$` (or future versioned equivalent).
+- `submitter.anonymous_token` format: `^anon_[a-z0-9]{16,64}$`.
+- Timestamp fields must be ISO-8601 UTC (`...Z`) or `null` where allowed.
+- `patch` must be non-empty array.
+- `status` must be in enum set.
+- Status-specific timestamp consistency must hold for the current record state (for example decision/applied timestamps required only when status requires them).
+
+### B) Semantic/business validation
+
+- `target_ir_id` exists in input IR dataset.
+- `provenance.target_snapshot.ir_version` matches the input IR version context.
+- Every patch op is allowed in v1 and path-constrained.
+- Patch applies cleanly to target record (no missing path/index errors).
+- Post-patch record remains valid IR record shape (existing IR schema validation).
+- Standalone validation does not assert historical transition legality across prior versions. That check is deferred to workflow/lifecycle validation in later correction pipeline logic.
+
+## Provenance and audit metadata
+
+The `provenance` object captures correction rationale and auditability:
+
+- `reason` (required): plain-text reason for correction.
+- `evidence_refs` (optional array of strings): external references, issue IDs, or source pointers.
+- `target_snapshot` (required):
+  - `ir_version` (required)
+  - `record_sha256` (required when `status` is `approved` or `applied`; recommended otherwise)
+- `audit` (required object):
+  - `submitted_via` (required enum): `manual_import` | `api` | `batch`
+  - `reviewer_token` (nullable string)
+  - `decision_note` (nullable string)
+  - `supersedes_correction_id` (nullable string)
+
+Audit principles:
+
+- Every status change updates `timestamps.updated_at`.
+- Decision statuses set `timestamps.reviewed_at` and `timestamps.decided_at`.
+- `applied` sets `timestamps.applied_at`.
+- Audit metadata is append-preserving: new decisions do not rewrite historical artifacts; they create new correctionset versions.
+
+## Files to create under `shared/specs/`
+
+Phase 1.5A deliverables:
+
+- `shared/specs/correction-record-schema-v1.md` (this spec; normative contract)
+
+Planned for implementation in Phase 1.5B:
+
+- `shared/specs/correction-application-dry-run.md` (pipeline behavior, inputs/outputs, conflict policy)
+
+## Tests needed for schema validation
+
+When implementation begins, add tests for:
+
+1. **Valid minimal correction record**
+   - required fields present
+   - single `replace` under `/fields_raw/...`
+2. **Status enum rejection**
+   - unknown `status` fails
+3. **Patch operation rejection**
+   - `copy`/`move`/`test` fail in v1
+4. **Path boundary enforcement**
+   - patch outside `/fields_raw` fails
+   - attempts to patch immutable fields fail
+5. **Target existence validation**
+   - missing `target_ir_id` in input IR fails
+6. **Patch application safety**
+   - invalid pointer/index path fails cleanly
+7. **Timestamp/state transition rules**
+   - standalone status/timestamp consistency enforced for current status
+   - full transition legality tested in lifecycle/workflow tests (separate from isolated record validation)
+8. **`record_sha256` applicability enforcement**
+   - `approved`/`applied` without `provenance.target_snapshot.record_sha256` fails
+   - non-applicable statuses may omit it
+9. **Deterministic replay**
+   - same correctionset + same IR snapshot produces byte-identical corrected IR output
+
+## How this supports later dry-run correction application
+
+This schema enables a deterministic correction pipeline by:
+
+- pinning each correction to a concrete target (`target_ir_id`)
+- constraining edits to RFC 6902 operations on mutable payload scope (`/fields_raw`)
+- defining explicit applicability (`status = approved`)
+- carrying snapshot/version metadata so input mismatch is detectable early
+- requiring audit metadata for traceable, reviewable correction history
+
+Phase 1.5B can therefore:
+
+1. load immutable IR snapshot
+2. filter approved corrections
+3. validate + apply patches in deterministic order
+4. emit a new versioned IR artifact
+5. emit an application report (eligible/applied-in-dry-run/rejected/conflicted)
+
+without mutating frozen historical datasets.
+
+Note: Phase 1.5B dry-run execution should not automatically persist lifecycle transition to `applied`; that state change belongs to a separate committed application/release workflow unless explicitly specified later.


### PR DESCRIPTION
Implement the Phase 1.5B backend-only correction dry-run flow with manifest/record validation, lifecycle and conflict handling, deterministic apply-on-copy outputs, and CLI/test coverage while preserving frozen datasets and non-persistent lifecycle state.

## What does this PR change?

- 

## Why?

- 

## Checklist (required)

- [ ] I kept this PR narrowly scoped.
- [ ] If I changed language data / meaning, I explained the impact and any uncertainty.
- [ ] If this touches third-party sources, I preserved attribution and did not add content without permission.
- [ ] If this changes normalization/transliteration behavior, I added examples (inputs → outputs) in the PR description.

## Screenshots / notes (if applicable)

- 

