### PR TITLE
feat(web): ship Phase 6B search-first UX layering

### DIFF
--- a/docs/PHASE_6B_CONSUMER_SEARCH_FIRST_UX.md
+++ b/docs/PHASE_6B_CONSUMER_SEARCH_FIRST_UX.md
@@ -1,0 +1,198 @@
+# Phase 6B Proposal: Consumer Search-First UX + Infrastructure Layering
+
+## Objective
+
+Make the default SiraLex experience self-serve for ordinary dictionary users while preserving the full infrastructure/management surface behind a secondary, clearly discoverable layer.
+
+SiraLex remains both:
+
+- a consumer offline dictionary experience, and
+- an offline-first dictionary platform/infrastructure surface.
+
+This milestone is a UX layering milestone, not an infrastructure rollback.
+
+## Core design question
+
+How should SiraLex expose:
+
+1. a simple dictionary-first consumer experience, and
+2. a powerful bundle/platform management experience,
+
+without making either one worse?
+
+## Pilot findings incorporated
+
+- Users could access/install the app, but needed guidance.
+- Catalog URL -> load catalog -> install dictionary is not self-explanatory.
+- Users do not naturally understand catalog/bundle concepts.
+- After install, management controls dominate visual priority above search.
+- Direction switching is understandable once shown.
+- One-word lookup feels useful.
+- Multiword/phrase lookup feels weaker/harder, consistent with earlier validation signals (partial phrase retrieval granularity).
+
+---
+
+## 1) Interface-layering principle
+
+Primary principle:
+
+- default surface = consumer task flow (install dictionary once, then search)
+- secondary surfaces = platform/operator workflows (catalog/manual import/diagnostics/registry management)
+
+Rules:
+
+- progressive disclosure for advanced capabilities
+- keep advanced capabilities fully available
+- remove visual competition on primary screen, not capability
+
+---
+
+## 2) First-run consumer flow
+
+### Primary path (consumer-first)
+
+- Show one prominent CTA: **Install dictionary**
+- CTA installs the **deployment-configured featured dictionary** without exposing catalog URL details
+- The current public deployment may feature French <-> Maninka, but the UX model must not assume one globally hardcoded dictionary forever
+- Copy should explain outcome in plain language (for example: "Install featured dictionary")
+
+### Secondary path (advanced setup)
+
+Provide a clearly labeled secondary entry point: **Advanced setup**, containing:
+
+- load custom catalog URL
+- manual bundle import/sideload
+
+No catalog URL field should appear in the first-run primary path.
+
+### First-run offline/failure fallback behavior
+
+Required behavior:
+
+- if no dictionary is installed and no network is available, show a clear offline-first recovery state (no silent failure)
+- if featured dictionary install fetch fails, show understandable failure message + retry action
+- include an explicit **Retry install** action in primary flow
+- keep **Advanced setup** available in failure states for:
+  - manual import recovery
+  - custom catalog recovery
+
+---
+
+## 3) Installed-state consumer layout
+
+After at least one dictionary is installed, the default screen should prioritize:
+
+1. search input
+2. direction toggle
+3. results list
+4. entry detail
+
+Active dictionary state should be visible but minimal (for example: compact "Using: <dictionary>" row with a manage link).
+
+If multiple dictionaries are installed, active dictionary switching should remain accessible either:
+
+- from the same compact primary-surface row, or
+- from Manage dictionaries,
+
+without reintroducing management clutter above search.
+
+Dictionary-management details should not dominate the top of the main screen.
+
+---
+
+## 4) Secondary management surface
+
+Recommended IA structure:
+
+- **Manage dictionaries** (primary secondary surface)
+  - installed bundle registry
+  - install/switch/remove dictionary
+  - dictionary metadata
+- **Advanced setup** (inside Manage dictionaries)
+  - catalog URL load flow
+  - manual bundle import
+- **Advanced diagnostics** (separate secondary surface)
+  - validation logging toggle
+  - export logs
+  - recent log inspection
+- **Settings** (app-level options, not dictionary operations or diagnostics)
+
+Recommendation:
+
+- use a split structure where **Manage dictionaries** is discoverable from main UI,
+- keep **Advanced setup** inside Manage dictionaries (collapsed/sectioned),
+- keep **Advanced diagnostics** as a separate secondary surface from dictionary management,
+- avoid hiding routine dictionary switching behind a generic Settings screen.
+
+---
+
+## 5) Validation/diagnostics surface
+
+Validation tooling remains available but should not compete with search-first UI.
+
+Information architecture rule:
+
+- **Manage dictionaries** owns bundle install/switch/remove/manual import/catalog controls
+- **Advanced diagnostics** is a separate secondary surface for validation logging/export/recent logs
+- diagnostics should not be conceptually buried inside dictionary management unless a specific future constraint requires it
+
+Default diagnostics entry may be visually minimized/collapsed, but it should remain clearly discoverable.
+
+---
+
+## First-run install progress and outcome states
+
+Primary featured-install path should expose plain-language progress states without requiring catalog/bundle terminology:
+
+1. **Install started**
+2. **Downloading/preparing dictionary**
+3. **Installed and ready to search**
+4. **Install failed** with understandable recovery actions (Retry, Advanced setup)
+
+Users should always understand what the app is currently doing and what to do next.
+
+---
+
+## 6) Preserve platform architecture (non-negotiable)
+
+This milestone must not remove or weaken:
+
+- catalog-driven install architecture
+- multi-bundle support
+- manual import/sideload path
+- validation/logging/export tooling
+
+Only UX layering and information architecture should change.
+
+---
+
+## 7) UX success criteria
+
+Phase 6B is complete when:
+
+- a first-time ordinary user can install the deployment-configured featured dictionary without explanation
+- after install, search is the primary visible task at page top
+- advanced tooling remains accessible but no longer dominates default layout
+- platform/operator workflows still function without regression
+
+---
+
+## 8) Search-quality signal (captured, not solved here)
+
+Confirmed early user signal:
+
+- multiword/phrase search is perceived as weaker than one-word lookup
+
+Handling rule for this milestone:
+
+- record this as a validated product/search quality signal
+- do not solve inside Phase 6B unless a separate scoped search-quality milestone is explicitly opened
+
+---
+
+## Out of scope for this milestone
+
+- Branch C linguistic feature implementation
+- `norm_v3` indexing changes
+- large correction UI/moderation workflow build
+- committed correction-release workflow UX

--- a/docs/PHASE_6_SMALL_USER_PILOT.md
+++ b/docs/PHASE_6_SMALL_USER_PILOT.md
@@ -1,0 +1,60 @@
+# Phase 6 Proposal: Small User Pilot + Real Feedback Loop
+
+## Objective
+
+Run a small real-user pilot to collect:
+
+- authentic search behavior in daily use
+- usability friction in install/import/search flows
+- concrete correction candidates for IR content quality
+
+This phase is evidence-gathering and prioritization, not feature expansion.
+
+## Pilot size and tester profile
+
+- Initial cohort: **5-10 testers**
+- Prioritize testers with relevance to **Maninka/French** use cases where possible
+- Include a mix of device/browser contexts (Android, iOS, desktop web when available)
+
+## Required pilot materials
+
+1. **One-page tester guide**
+   - quick start, pilot goal, what to do, what to report
+2. **Feedback form/template**
+   - structured capture for misses, wrong entries, friction, and device context
+3. **Pilot tracking log**
+   - lightweight operator log to track tester status, submissions, and follow-ups
+
+## Tester flow
+
+1. Open app
+2. Install/add to home screen if desired
+3. Load dictionary via catalog install flow
+4. Enable validation logging
+5. Search naturally (real usage, not scripted only)
+6. Export logs
+7. Submit feedback form/template plus exported logs
+
+## Evidence to collect
+
+- exported query logs (validation format)
+- reported misses and wrong entries
+- installation/import friction notes
+- device/browser-specific issues
+- candidate corrections (content and indexing relevance)
+
+## Exit criteria
+
+Phase 6 completes when:
+
+- logs + feedback are collected from at least several testers (target cohort: 5-10)
+- recurring patterns are identified across search/content/usability signals
+- at least one actionable correction candidate or index-improvement signal is identified from real usage
+
+## Boundaries
+
+- No Branch C implementation yet
+- No `norm_v3` work yet
+- No large correction UI/moderation system yet
+
+This phase is intentionally small, real-user focused, and evidence-first.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -290,8 +290,18 @@ DoD:
 | 16 | Phase 1.5B — Dry-run correction application pipeline | Follows 1.5A approval | ✅ Complete |
 | 17 | HTTPS + Android validation execution | Active validation follow-up | Pending hardware access |
 | 18 | Branch C — Transliteration, morphology, linguistic inference | Only after users + data | Deferred |
+| 19 | Phase 6B — Consumer Search-First UX + Infrastructure Layering | UX/product milestone | ✅ Complete |
 
-Phase 2.0 (Branch A) and the originally planned Phase 3 platform work have now served their purpose: the runtime proves bundle ingestion, IndexedDB storage, query execution, rendering, offline shell behavior, manifest-driven language metadata, installed bundle registry, active bundle selection, multi-bundle isolation, and catalog-driven install/update flows. The roadmap was previously lagging behind this implementation reality. Search/index quality is no longer a single undifferentiated pending bucket: **Phase 5a** is now treated as complete because `norm_v2` indexing has been implemented and validated, while **Phase 5b** is now substantially complete with Android real-device validation explicitly deferred until hardware access resumes. With that transition, **Phase 1.5A** (correction record schema/specification) and **Phase 1.5B** (dry-run correction application pipeline) are complete for backend dry-run scope. UI/moderation workflows and committed correction-release lifecycle persistence remain intentionally out of scope for this completion state. Branch C remains explicitly deferred until real usage data exists.
+Phase 2.0 (Branch A) and the originally planned Phase 3 platform work have now served their purpose: the runtime proves bundle ingestion, IndexedDB storage, query execution, rendering, offline shell behavior, manifest-driven language metadata, installed bundle registry, active bundle selection, multi-bundle isolation, and catalog-driven install/update flows. The roadmap was previously lagging behind this implementation reality. Search/index quality is no longer a single undifferentiated pending bucket: **Phase 5a** is now treated as complete because `norm_v2` indexing has been implemented and validated, while **Phase 5b** is now substantially complete with Android real-device validation explicitly deferred until hardware access resumes. With that transition, **Phase 1.5A** (correction record schema/specification) and **Phase 1.5B** (dry-run correction application pipeline) are complete for backend dry-run scope, and **Phase 6B** is complete for consumer UX layering scope. UI/moderation workflows and committed correction-release lifecycle persistence remain intentionally out of scope for this completion state. Branch C remains explicitly deferred until real usage data exists.
+
+### Phase 6B — Consumer Search-First UX + Infrastructure Layering ✅
+
+Completion note:
+
+- consumer search-first UX layering shipped
+- featured dictionary primary install path shipped
+- Manage dictionaries and Advanced diagnostics remain available as secondary infrastructure surfaces
+- no platform capabilities were removed (catalog-driven install, multi-bundle support, manual import, validation diagnostics)
 
 The completed Phase 2.0 work followed clean layer separation:
 

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -72,6 +72,10 @@ if (!app) {
   throw new Error("Missing #app root");
 }
 
+const FEATURED_CATALOG_URL =
+  import.meta.env.VITE_FEATURED_CATALOG_URL?.trim() || "/catalog.json";
+const FEATURED_BUNDLE_ID = import.meta.env.VITE_FEATURED_BUNDLE_ID?.trim() || undefined;
+
 app.innerHTML = `
   <div class="container">
     <div class="card">
@@ -80,51 +84,80 @@ app.innerHTML = `
     </div>
 
     <div class="card" style="margin-top: 16px">
-      <h2 class="title" style="font-size: 16px; margin-bottom: 8px">Dictionary</h2>
+      <h2 class="title" style="font-size: 16px; margin-bottom: 8px">Search</h2>
+      <p class="subtitle">Dictionary-first experience. Install a dictionary if needed, then search.</p>
       <div id="dictStatus" class="mono"></div>
+      <div id="firstRun" style="display: none; margin-top: 12px; padding: 10px; border: 1px solid var(--border); border-radius: 8px">
+        <div id="featuredInstallStatus" class="mono"></div>
+        <div class="row" style="margin-top: 10px; gap: 8px">
+          <button id="featuredInstall" class="btn">Install dictionary</button>
+          <button id="retryFeaturedInstall" class="btn" style="display: none">Retry install</button>
+        </div>
+      </div>
+
+      <div id="activeDictionaryRow" style="margin-top: 12px; padding: 10px; border: 1px solid var(--border); border-radius: 8px">
+        <div class="row" style="align-items: center; justify-content: space-between; gap: 8px">
+          <div class="mono" id="activeDictionarySummary">No active dictionary</div>
+          <button id="openManageDictionaries" class="btn" type="button">Manage dictionaries</button>
+        </div>
+      </div>
+
       <div class="row" style="margin-top: 12px; align-items: center">
         <div class="field" style="flex: 1">
-          <div class="label">Installed dictionaries</div>
-          <select id="bundleSelect" disabled>
-            <option value="">No dictionaries installed</option>
-          </select>
+          <div class="label" id="searchLabel">Query (Source → Target)</div>
+          <input id="searchInput" type="text" placeholder="Type a Source word…" disabled autocomplete="off" />
         </div>
+        <button id="langToggle" class="btn" disabled>Source → Target</button>
       </div>
-      <div id="installedBundleStatus" class="mono" style="margin-top: 12px"></div>
-      <div id="installedBundleList" style="margin-top: 12px"></div>
-      <div class="row" style="margin-top: 12px; align-items: end">
-        <div class="field" style="flex: 1">
-          <div class="label">Catalog URL</div>
-          <input id="catalogUrl" type="text" placeholder="https://example.org/catalog.json or /catalog.json" autocomplete="off" />
-        </div>
-        <button id="loadCatalog" class="btn">Load catalog</button>
-      </div>
-      <div id="catalogStatus" class="mono" style="margin-top: 12px"></div>
-      <div id="catalogList" style="margin-top: 12px"></div>
-      <div id="firstRun" style="display: none; margin-top: 12px">
-        <p style="color: var(--muted); font-size: 14px; margin: 0 0 12px 0">
-          No dictionary installed.<br>
-          Download a dictionary bundle and import it.
-        </p>
-      </div>
-      <div class="row" style="margin-top: 12px">
-        <button id="quickImport" class="btn">Install bundle files</button>
-        <input id="quickImportFiles" type="file" multiple style="display: none" />
-        <button id="cancelInstall" class="btn" style="display: none">Cancel install</button>
-      </div>
-      <div id="importProgress" class="mono" style="margin-top: 12px; display: none"></div>
-      <div class="row" style="margin-top: 12px">
-        <button id="clearDb" class="btn">Delete database</button>
-      </div>
+
+      <div id="searchMeta" class="mono" style="margin-top: 12px"></div>
+      <div id="searchResults" style="margin-top: 12px"></div>
     </div>
 
-    <div class="card" style="margin-top: 16px">
-      <h2 class="title" style="font-size: 16px; margin-bottom: 8px">Search</h2>
-      <p class="subtitle">
-        Type a query to search the dictionary. Uses the exactness ladder: casefold → diacritics_insensitive → punct_stripped → nospace.
-      </p>
+    <details id="manageDictionariesPanel" style="margin-top: 16px">
+      <summary style="color: var(--muted); font-size: 13px; cursor: pointer; padding: 8px 0">Manage dictionaries</summary>
+      <div class="card" style="margin-top: 8px">
+        <h2 class="title" style="font-size: 16px; margin-bottom: 8px">Manage dictionaries</h2>
+        <div class="row" style="margin-top: 12px; align-items: center">
+          <div class="field" style="flex: 1">
+            <div class="label">Installed dictionaries</div>
+            <select id="bundleSelect" disabled>
+              <option value="">No dictionaries installed</option>
+            </select>
+          </div>
+        </div>
+        <div id="installedBundleStatus" class="mono" style="margin-top: 12px"></div>
+        <div id="installedBundleList" style="margin-top: 12px"></div>
 
-      <div style="margin-top: 12px; padding: 10px; border: 1px solid var(--border); border-radius: 8px">
+        <details style="margin-top: 12px">
+          <summary style="color: var(--muted); font-size: 13px; cursor: pointer">Advanced setup</summary>
+          <div class="row" style="margin-top: 12px; align-items: end">
+            <div class="field" style="flex: 1">
+              <div class="label">Catalog URL</div>
+              <input id="catalogUrl" type="text" placeholder="https://example.org/catalog.json or /catalog.json" autocomplete="off" />
+            </div>
+            <button id="loadCatalog" class="btn">Load catalog</button>
+          </div>
+          <div id="catalogStatus" class="mono" style="margin-top: 12px"></div>
+          <div id="catalogList" style="margin-top: 12px"></div>
+          <div class="row" style="margin-top: 12px">
+            <button id="quickImport" class="btn">Install bundle files</button>
+            <input id="quickImportFiles" type="file" multiple style="display: none" />
+            <button id="cancelInstall" class="btn" style="display: none">Cancel install</button>
+          </div>
+        </details>
+
+        <div id="importProgress" class="mono" style="margin-top: 12px; display: none"></div>
+        <div class="row" style="margin-top: 12px">
+          <button id="clearDb" class="btn">Delete database</button>
+        </div>
+      </div>
+    </details>
+
+    <details style="margin-top: 16px">
+      <summary style="color: var(--muted); font-size: 13px; cursor: pointer; padding: 8px 0">Advanced diagnostics</summary>
+      <div class="card" style="margin-top: 8px">
+        <h2 class="title" style="font-size: 16px; margin-bottom: 8px">Validation diagnostics</h2>
         <div class="row" style="align-items: center; justify-content: space-between; gap: 12px">
           <div>
             <div class="label">Validation logging</div>
@@ -152,18 +185,7 @@ app.innerHTML = `
           </div>
         </div>
       </div>
-
-      <div class="row" style="margin-top: 12px; align-items: center">
-        <div class="field" style="flex: 1">
-          <div class="label" id="searchLabel">Query (Source → Target)</div>
-          <input id="searchInput" type="text" placeholder="Type a Source word…" disabled autocomplete="off" />
-        </div>
-        <button id="langToggle" class="btn" disabled>Source → Target</button>
-      </div>
-
-      <div id="searchMeta" class="mono" style="margin-top: 12px"></div>
-      <div id="searchResults" style="margin-top: 12px"></div>
-    </div>
+    </details>
 
     <details style="margin-top: 16px">
       <summary style="color: var(--muted); font-size: 13px; cursor: pointer; padding: 8px 0">Developer tools</summary>
@@ -227,6 +249,12 @@ function mustGetEl<T extends Element>(selector: string): T {
 
 // Primary UI elements
 const dictStatus = mustGetEl<HTMLDivElement>("#dictStatus");
+const activeDictionarySummary = mustGetEl<HTMLDivElement>("#activeDictionarySummary");
+const openManageDictionariesBtn = mustGetEl<HTMLButtonElement>("#openManageDictionaries");
+const manageDictionariesPanel = mustGetEl<HTMLDetailsElement>("#manageDictionariesPanel");
+const featuredInstallStatus = mustGetEl<HTMLDivElement>("#featuredInstallStatus");
+const featuredInstallBtn = mustGetEl<HTMLButtonElement>("#featuredInstall");
+const retryFeaturedInstallBtn = mustGetEl<HTMLButtonElement>("#retryFeaturedInstall");
 const bundleSelect = mustGetEl<HTMLSelectElement>("#bundleSelect");
 const installedBundleStatus = mustGetEl<HTMLDivElement>("#installedBundleStatus");
 const installedBundleList = mustGetEl<HTMLDivElement>("#installedBundleList");
@@ -282,6 +310,7 @@ let loadedCatalogSource: "network" | "cache" | undefined;
 let remoteInstallAbortController: AbortController | undefined;
 let remoteInstallBundleId: string | undefined;
 let currentStorageEstimate: { usage?: number; quota?: number } | undefined;
+let featuredInstallInProgress = false;
 
 function formatErrorDetails(e: unknown): string {
   const details = [`String(e): ${String(e)}`];
@@ -533,6 +562,12 @@ function updateInstallControls() {
   cancelInstallBtn.disabled = !installInProgress;
 }
 
+function updateFeaturedInstallControls() {
+  const disabled = busy || featuredInstallInProgress;
+  featuredInstallBtn.disabled = disabled;
+  retryFeaturedInstallBtn.disabled = disabled;
+}
+
 function buildCachedCatalogSnapshot(
   requestUrl: string,
   responseUrl: string,
@@ -589,6 +624,12 @@ manifestFile.addEventListener("change", () => {
 updateButtons();
 updateCatalogControls();
 updateInstallControls();
+updateFeaturedInstallControls();
+
+openManageDictionariesBtn.addEventListener("click", () => {
+  manageDictionariesPanel.open = true;
+  manageDictionariesPanel.scrollIntoView({ behavior: "smooth", block: "start" });
+});
 
 catalogUrlInput.addEventListener("input", () => {
   updateCatalogControls();
@@ -786,6 +827,9 @@ async function refreshDbStatus() {
       if (active) {
         hasActiveBundle = true;
         firstRun.style.display = "none";
+        retryFeaturedInstallBtn.style.display = "none";
+        featuredInstallStatus.textContent = "";
+        activeDictionarySummary.textContent = `Using: ${getInstalledBundleName(active)} — ready to search`;
         const statusText =
           `Active: ${getInstalledBundleName(active)}\n` +
           `Bundle ID: ${active.bundle_id}\n` +
@@ -795,10 +839,11 @@ async function refreshDbStatus() {
           `Imported: ${active.imported_at_iso}\n` +
           `Records: ${active.records_count ?? "n/a"} | Index entries: ${active.index_entries_count ?? "n/a"}\n` +
           `Approx payload: ${fmtBytes(active.storage_bytes)}\n`;
-        dictStatus.textContent = statusText;
+        dictStatus.textContent = "Dictionary ready for offline search.";
         dbOut.textContent = statusText;
       } else {
         hasActiveBundle = false;
+        activeDictionarySummary.textContent = "No active dictionary";
         const hasRecordsData = await storeHasData(db, STORE_RECORDS);
         const hasIndexData = await storeHasData(db, STORE_SEARCH_INDEX);
         if (bundles.length > 0) {
@@ -821,7 +866,18 @@ async function refreshDbStatus() {
         } else {
           firstRun.style.display = "";
           importProgress.style.display = "none";
-          dictStatus.textContent = "";
+          if (!navigator.onLine) {
+            featuredInstallStatus.textContent =
+              "No dictionary installed and you appear to be offline.\n" +
+              "Connect and retry featured install, or use Manage dictionaries → Advanced setup.";
+            retryFeaturedInstallBtn.style.display = "";
+          } else {
+            featuredInstallStatus.textContent =
+              "Install the deployment-configured featured dictionary to start searching.\n" +
+              "Advanced setup is available for custom catalogs and manual import.";
+            retryFeaturedInstallBtn.style.display = "none";
+          }
+          dictStatus.textContent = "No active dictionary installed yet.";
           dbOut.textContent = "No active bundle.\n";
         }
       }
@@ -843,6 +899,7 @@ async function refreshDbStatus() {
   renderCatalogList();
   searchInput.disabled = !hasActiveBundle || busy;
   langToggle.disabled = !hasActiveBundle || busy;
+  updateFeaturedInstallControls();
   if (!hasActiveBundle) {
     searchMeta.textContent = "";
     searchResults.innerHTML = "";
@@ -1025,13 +1082,17 @@ async function quickImportBundle(fileList: FileList) {
 
 // --- Catalog loading (Phase 4.1) ---
 
-async function loadCatalogFromUrl() {
-  const catalogUrl = catalogUrlInput.value.trim();
+async function loadCatalogFromUrl(
+  catalogUrlOverride?: string,
+  statusTarget: HTMLDivElement = catalogStatus,
+  opts: { updateCatalogInput?: boolean } = {},
+) {
+  const catalogUrl = (catalogUrlOverride ?? catalogUrlInput.value).trim();
   if (catalogUrl === "") return;
 
   catalogLoading = true;
   updateCatalogControls();
-  catalogStatus.textContent = `Loading catalog from ${catalogUrl}...\n`;
+  statusTarget.textContent = `Loading catalog from ${catalogUrl}...\n`;
 
   try {
     const result = await fetchBundleCatalog(catalogUrl, {
@@ -1050,7 +1111,10 @@ async function loadCatalogFromUrl() {
       db.close();
     }
     applyCachedCatalog(cached, "network");
-    catalogStatus.textContent =
+    if (opts.updateCatalogInput !== false) {
+      catalogUrlInput.value = catalogUrl;
+    }
+    statusTarget.textContent =
       `Catalog loaded.\n` +
       `Source: ${result.responseUrl}\n` +
       `Bundles: ${result.catalog.bundles.length}\n` +
@@ -1058,19 +1122,73 @@ async function loadCatalogFromUrl() {
       `Remote policy: https anywhere; http only for same-origin or local hubs (localhost, .local, private IPs).\n` +
       `Bundle URL contract: url_base + bundle.manifest.json / records.jsonl / search_index.jsonl\n`;
     for (const warning of result.warnings) {
-      catalogStatus.textContent += `WARN: ${warning}\n`;
+      statusTarget.textContent += `WARN: ${warning}\n`;
     }
+    return result.catalog.bundles;
   } catch (e) {
-    catalogStatus.textContent = `Catalog load failed: ${String(e)}\n`;
+    statusTarget.textContent = `Catalog load failed: ${String(e)}\n`;
     if (loadedCatalogBundles.length > 0 && loadedCatalogUrl && loadedCatalogFetchedAtIso) {
-      catalogStatus.textContent +=
+      statusTarget.textContent +=
         `Showing cached catalog from ${loadedCatalogUrl}\n` +
         `Fetched at: ${loadedCatalogFetchedAtIso}\n`;
     }
+    throw e;
   } finally {
     catalogLoading = false;
     updateCatalogControls();
     renderCatalogList();
+  }
+}
+
+function getFeaturedCatalogEntry(): BundleCatalogEntryV1 | undefined {
+  if (FEATURED_BUNDLE_ID) {
+    return loadedCatalogBundles.find((entry) => entry.bundle_id === FEATURED_BUNDLE_ID);
+  }
+  return loadedCatalogBundles[0];
+}
+
+async function installFeaturedDictionary() {
+  if (busy || featuredInstallInProgress) return;
+  featuredInstallInProgress = true;
+  updateFeaturedInstallControls();
+  retryFeaturedInstallBtn.style.display = "none";
+  featuredInstallStatus.textContent = "Install started.\n";
+
+  try {
+    if (!navigator.onLine && installedBundles.length === 0) {
+      featuredInstallStatus.textContent =
+        "No dictionary installed and no network connection detected.\n" +
+        "Connect and retry, or use Manage dictionaries → Advanced setup for manual import/custom catalog recovery.";
+      retryFeaturedInstallBtn.style.display = "";
+      return;
+    }
+
+    featuredInstallStatus.textContent += "Downloading/preparing dictionary...\n";
+    await withSingleWriterLock("install featured dictionary", async () => {
+      await loadCatalogFromUrl(FEATURED_CATALOG_URL, featuredInstallStatus, { updateCatalogInput: false });
+      const entry = getFeaturedCatalogEntry();
+      if (!entry) {
+        throw new Error("No featured dictionary entry found in catalog");
+      }
+      const installResult = await installCatalogEntry(entry, true, featuredInstallStatus);
+      if (!installResult.ok) {
+        throw new Error(installResult.message);
+      }
+    });
+
+    featuredInstallStatus.textContent =
+      "Installed and ready to search.\n" +
+      "Manage dictionaries and advanced setup remain available from Manage dictionaries.";
+    dictStatus.textContent = "Dictionary installed and ready for offline search.";
+  } catch (e) {
+    featuredInstallStatus.textContent =
+      "Install failed.\n" +
+      `${String(e)}\n` +
+      "Retry install or open Manage dictionaries → Advanced setup for recovery.";
+    retryFeaturedInstallBtn.style.display = "";
+  } finally {
+    featuredInstallInProgress = false;
+    updateFeaturedInstallControls();
   }
 }
 
@@ -1093,11 +1211,15 @@ async function restoreCachedCatalogFromDb() {
   }
 }
 
-async function installCatalogEntry(entry: BundleCatalogEntryV1, activateOnCommit = true) {
+async function installCatalogEntry(
+  entry: BundleCatalogEntryV1,
+  activateOnCommit = true,
+  progressTarget: HTMLDivElement = importProgress,
+): Promise<{ ok: boolean; message: string }> {
   if (!loadedCatalogUrl) {
-    importProgress.style.display = "";
-    importProgress.textContent = "No catalog source URL is available for this entry.\n";
-    return;
+    progressTarget.style.display = "";
+    progressTarget.textContent = "No catalog source URL is available for this entry.\n";
+    return { ok: false, message: "missing catalog source URL" };
   }
 
   const existingDb = await openSiralexDb();
@@ -1105,9 +1227,9 @@ async function installCatalogEntry(entry: BundleCatalogEntryV1, activateOnCommit
     const installed = await getInstalledBundleMeta(existingDb, entry.bundle_id);
     if (installed?.expected_content_sha256 === entry.content_sha256) {
       await setActiveBundleId(existingDb, entry.bundle_id);
-      importProgress.style.display = "";
-      importProgress.textContent = `Bundle already installed. Marked active: ${entry.bundle_id}\n`;
-      return;
+      progressTarget.style.display = "";
+      progressTarget.textContent = `Bundle already installed. Marked active: ${entry.bundle_id}\n`;
+      return { ok: true, message: "already installed; activated" };
     }
   } finally {
     existingDb.close();
@@ -1117,8 +1239,8 @@ async function installCatalogEntry(entry: BundleCatalogEntryV1, activateOnCommit
   remoteInstallAbortController = controller;
   remoteInstallBundleId = entry.bundle_id;
   updateInstallControls();
-  importProgress.style.display = "";
-  importProgress.textContent = `Preparing remote install for ${entry.bundle_id}...\n`;
+  progressTarget.style.display = "";
+  progressTarget.textContent = `Preparing remote install for ${entry.bundle_id}...\n`;
 
   const db = await openSiralexDb();
   try {
@@ -1126,7 +1248,7 @@ async function installCatalogEntry(entry: BundleCatalogEntryV1, activateOnCommit
       activateOnCommit,
       signal: controller.signal,
       onUpdate: (message) => {
-        importProgress.textContent = message;
+        progressTarget.textContent = message;
       },
       storageEstimate:
         typeof navigator !== "undefined" && navigator.storage?.estimate
@@ -1136,21 +1258,24 @@ async function installCatalogEntry(entry: BundleCatalogEntryV1, activateOnCommit
 
     if (result.skippedBecauseCurrent) {
       await setActiveBundleId(db, manifest.bundle_id);
-      importProgress.textContent = `Bundle already installed. Marked active: ${manifest.bundle_id}\n`;
+      progressTarget.textContent = `Bundle already installed. Marked active: ${manifest.bundle_id}\n`;
+      return { ok: true, message: "already installed; activated" };
     } else {
-      importProgress.textContent =
+      progressTarget.textContent =
         `Remote install complete: ${manifest.bundle_id}\n` +
         `${result.recordsCount} records, ${result.indexCount} index entries\n` +
         `${result.elapsedMs.toFixed(0)} ms\n`;
       if (result.cleanupWarning) {
-        importProgress.textContent += `\n${result.cleanupWarning}\n`;
+        progressTarget.textContent += `\n${result.cleanupWarning}\n`;
       }
+      return { ok: true, message: "installed" };
     }
   } catch (e) {
     console.error("REMOTE INSTALL FAILED", e);
-    importProgress.textContent =
+    progressTarget.textContent =
       `Install FAILED\n` +
       `${formatErrorDetails(e)}\n`;
+    return { ok: false, message: String(e) };
   } finally {
     remoteInstallAbortController = undefined;
     remoteInstallBundleId = undefined;
@@ -1160,7 +1285,15 @@ async function installCatalogEntry(entry: BundleCatalogEntryV1, activateOnCommit
 }
 
 loadCatalogBtn.addEventListener("click", () => {
-  void loadCatalogFromUrl();
+  void loadCatalogFromUrl(undefined, catalogStatus, { updateCatalogInput: true });
+});
+
+featuredInstallBtn.addEventListener("click", () => {
+  void installFeaturedDictionary();
+});
+
+retryFeaturedInstallBtn.addEventListener("click", () => {
+  void installFeaturedDictionary();
 });
 
 // --- Developer tools: manifest validation ---


### PR DESCRIPTION
Re-layer the app to a consumer-first dictionary workflow with featured install entry, secondary management/diagnostics surfaces, and roadmap/spec updates while preserving catalog, multi-bundle, manual import, and validation infrastructure.

## What does this PR change?

- 

## Why?

- 

## Checklist (required)

- [ ] I kept this PR narrowly scoped.
- [ ] If I changed language data / meaning, I explained the impact and any uncertainty.
- [ ] If this touches third-party sources, I preserved attribution and did not add content without permission.
- [ ] If this changes normalization/transliteration behavior, I added examples (inputs → outputs) in the PR description.

## Screenshots / notes (if applicable)

- 

