### PR TITLE
feat(web): add French-first interface localization and language toggle

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -291,6 +291,7 @@ DoD:
 | 17 | HTTPS + Android validation execution | Active validation follow-up | Pending hardware access |
 | 18 | Branch C — Transliteration, morphology, linguistic inference | Only after users + data | Deferred |
 | 19 | Phase 6B — Consumer Search-First UX + Infrastructure Layering | UX/product milestone | ✅ Complete |
+| 20 | Phase 6D1 — Localization Architecture + French-First Interface Pass | Near-term consumer productization milestone | Implemented (pending review) |
 
 Phase 2.0 (Branch A) and the originally planned Phase 3 platform work have now served their purpose: the runtime proves bundle ingestion, IndexedDB storage, query execution, rendering, offline shell behavior, manifest-driven language metadata, installed bundle registry, active bundle selection, multi-bundle isolation, and catalog-driven install/update flows. The roadmap was previously lagging behind this implementation reality. Search/index quality is no longer a single undifferentiated pending bucket: **Phase 5a** is now treated as complete because `norm_v2` indexing has been implemented and validated, while **Phase 5b** is now substantially complete with Android real-device validation explicitly deferred until hardware access resumes. With that transition, **Phase 1.5A** (correction record schema/specification) and **Phase 1.5B** (dry-run correction application pipeline) are complete for backend dry-run scope, and **Phase 6B** is complete for consumer UX layering scope. UI/moderation workflows and committed correction-release lifecycle persistence remain intentionally out of scope for this completion state. Branch C remains explicitly deferred until real usage data exists.
 
@@ -309,6 +310,53 @@ The completed Phase 2.0 work followed clean layer separation:
 - **2.0.3b** = retrieval correctness (query execution) ✅
 - **2.0.4** = presentation correctness (results display + entry view) ✅
 - **2.0.5** = offline correctness (PWA first-install → offline proof) ✅
+
+#### Phase 6D1 — Localization Architecture + French-first interface pass *(implemented, review pending)*
+
+Rationale:
+
+- the dictionary content is French ↔ Maninka
+- Guinea-facing users are more likely to expect a French interface than an English-first shell
+- the current English-first app shell creates audience mismatch even when dictionary behavior is correct
+- this is UI localization work; it is not Branch C linguistic depth and not a data-model change
+
+Implemented scope:
+
+1. **French UI copy coverage** for:
+   - first-run install flow
+   - search screen
+   - progress/success/failure messages
+   - offline fallback text
+   - Manage dictionaries
+   - Advanced setup
+   - Advanced diagnostics
+   - empty states and action buttons
+
+2. **Lightweight localization architecture**:
+   - keyed UI strings
+   - current locale selection
+   - English and French supported initially
+
+3. **Deployment intent**:
+   - current Guinea-facing/public deployment should likely default to French
+   - English remains available as an optional interface language (or deployment-level configuration)
+
+Implementation notes:
+
+- lightweight keyed string layer introduced for consumer shell copy with `en` and `fr`
+- deployment-configured default locale support added (`VITE_DEFAULT_LOCALE`) with fallback order: configured locale → browser locale → `fr`
+- architecture supports future in-app locale toggle; visible toggle intentionally deferred to avoid introducing new UX controls during this pass
+- for Guinea-facing/public Netlify deployment, set `VITE_DEFAULT_LOCALE=fr` to enforce French-first UI regardless of browser locale
+
+Boundaries preserved:
+
+- do not alter dictionary content language coverage
+- do not conflate this phase with Branch C transliteration/morphology work
+
+Sequencing note:
+
+- Phase 6C UX revalidation can proceed on the current build
+- Phase 6D should be considered soon after (or alongside) pilot analysis because it directly affects self-serve audience fit
 
 #### Phase 2.0.3 — Hardening items (tracked for next PR)
 

--- a/web/src/bundle_labels.ts
+++ b/web/src/bundle_labels.ts
@@ -21,18 +21,23 @@ export function buildLanguageMetaFromManifest(manifest: BundleManifestV1): Bundl
   return Object.values(meta).some((value) => value !== undefined) ? meta : undefined;
 }
 
-export function getSourceLabel(meta?: BundleLanguageMeta): string {
-  return meta?.source_label ?? normalizeCode(meta?.source_lang) ?? "Source";
+export function getSourceLabel(meta?: BundleLanguageMeta, fallbackLabel = "Source"): string {
+  return meta?.source_label ?? normalizeCode(meta?.source_lang) ?? fallbackLabel;
 }
 
-export function getTargetLabel(meta?: BundleLanguageMeta): string {
-  return meta?.target_label ?? normalizeCode(meta?.target_lang) ?? "Target";
+export function getTargetLabel(meta?: BundleLanguageMeta, fallbackLabel = "Target"): string {
+  return meta?.target_label ?? normalizeCode(meta?.target_lang) ?? fallbackLabel;
 }
 
-export function getBundleDisplayName(bundleId: string, meta?: BundleLanguageMeta): string {
-  const source = getSourceLabel(meta);
-  const target = getTargetLabel(meta);
-  if (source === "Source" && target === "Target") {
+export function getBundleDisplayName(
+  bundleId: string,
+  meta?: BundleLanguageMeta,
+  sourceFallbackLabel = "Source",
+  targetFallbackLabel = "Target",
+): string {
+  const source = getSourceLabel(meta, sourceFallbackLabel);
+  const target = getTargetLabel(meta, targetFallbackLabel);
+  if (source === sourceFallbackLabel && target === targetFallbackLabel) {
     return bundleId;
   }
   return `${source} ↔ ${target}`;
@@ -41,23 +46,30 @@ export function getBundleDisplayName(bundleId: string, meta?: BundleLanguageMeta
 export function getSearchDirectionText(
   direction: SearchDirection,
   meta?: BundleLanguageMeta,
+  sourceFallbackLabel = "Source",
+  targetFallbackLabel = "Target",
 ): string {
-  const source = getSourceLabel(meta);
-  const target = getTargetLabel(meta);
+  const source = getSourceLabel(meta, sourceFallbackLabel);
+  const target = getTargetLabel(meta, targetFallbackLabel);
   return direction === "source_to_target" ? `${source} → ${target}` : `${target} → ${source}`;
 }
 
 export function getSearchPlaceholder(
   direction: SearchDirection,
   meta?: BundleLanguageMeta,
+  sourceFallbackLabel = "Source",
+  targetFallbackLabel = "Target",
+  formatLabelWord: (label: string) => string = (label) => `Type a ${label} word…`,
 ): string {
-  const source = getSourceLabel(meta);
-  const target = getTargetLabel(meta);
-  return direction === "source_to_target"
-    ? `Type a ${source} word…`
-    : `Type a ${target} word…`;
+  const source = getSourceLabel(meta, sourceFallbackLabel);
+  const target = getTargetLabel(meta, targetFallbackLabel);
+  return direction === "source_to_target" ? formatLabelWord(source) : formatLabelWord(target);
 }
 
-export function getTargetEntriesLabel(meta?: BundleLanguageMeta): string {
-  return `${getTargetLabel(meta)} entries:`;
+export function getTargetEntriesLabel(
+  meta?: BundleLanguageMeta,
+  targetFallbackLabel = "Target",
+  formatEntriesLabel: (label: string) => string = (label) => `${label} entries:`,
+): string {
+  return formatEntriesLabel(getTargetLabel(meta, targetFallbackLabel));
 }

--- a/web/src/i18n.test.ts
+++ b/web/src/i18n.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  UI_LOCALE_STORAGE_KEY,
+  getCurrentLocale,
+  getSavedLocalePreference,
+  resolveDefaultLocale,
+  setCurrentLocale,
+  setCurrentLocaleWithPersistence,
+  setSavedLocalePreference,
+  t,
+} from "./i18n";
+
+function createMockStorage(initial: Record<string, string> = {}) {
+  const data = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+  };
+}
+
+describe("i18n locale resolution", () => {
+  it("saved preference wins over deployment default", () => {
+    const storage = createMockStorage({ [UI_LOCALE_STORAGE_KEY]: "en" });
+    expect(resolveDefaultLocale("fr", "fr-FR", storage)).toBe("en");
+  });
+
+  it("deployment default wins when no saved preference", () => {
+    const storage = createMockStorage();
+    expect(resolveDefaultLocale("fr", "en-US", storage)).toBe("fr");
+    expect(resolveDefaultLocale("en", "fr-FR", storage)).toBe("en");
+  });
+
+  it("invalid saved preference is ignored", () => {
+    const storage = createMockStorage({ [UI_LOCALE_STORAGE_KEY]: "de" });
+    expect(resolveDefaultLocale("fr", "en-US", storage)).toBe("fr");
+  });
+
+  it("falls back to browser locale, then french", () => {
+    const storage = createMockStorage();
+    expect(resolveDefaultLocale("de", "en-GB", storage)).toBe("en");
+    expect(resolveDefaultLocale(undefined, undefined, storage)).toBe("fr");
+    expect(resolveDefaultLocale("de", "es-ES", storage)).toBe("fr");
+  });
+});
+
+describe("i18n locale persistence", () => {
+  it("setting saved locale writes to storage", () => {
+    const storage = createMockStorage();
+    setSavedLocalePreference("fr", storage);
+    expect(storage.getItem(UI_LOCALE_STORAGE_KEY)).toBe("fr");
+  });
+
+  it("setCurrentLocaleWithPersistence updates current locale and storage", () => {
+    const previous = getCurrentLocale();
+    const storage = createMockStorage();
+    setCurrentLocaleWithPersistence("en", storage);
+    expect(getCurrentLocale()).toBe("en");
+    expect(storage.getItem(UI_LOCALE_STORAGE_KEY)).toBe("en");
+    setCurrentLocale(previous);
+  });
+
+  it("reads saved locale safely", () => {
+    const storage = createMockStorage({ [UI_LOCALE_STORAGE_KEY]: "fr" });
+    expect(getSavedLocalePreference(storage)).toBe("fr");
+  });
+});
+
+describe("i18n translations", () => {
+  it("uses active locale translations with interpolation", () => {
+    const previous = getCurrentLocale();
+    setCurrentLocale("fr");
+    expect(t("search.queryLabel", { direction: "FR → Mnk" })).toBe("Requête (FR → Mnk)");
+    setCurrentLocale("en");
+    expect(t("search.queryLabel", { direction: "FR → Mnk" })).toBe("Query (FR → Mnk)");
+    setCurrentLocale(previous);
+  });
+});
+

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -1,0 +1,477 @@
+export type Locale = "en" | "fr";
+export const UI_LOCALE_STORAGE_KEY = "siralex.ui_locale";
+
+const SUPPORTED_LOCALES: readonly Locale[] = ["en", "fr"] as const;
+type LocaleStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+function normalizeLocaleTag(value: string | undefined): Locale | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase().replace("_", "-");
+  if (normalized === "") return undefined;
+  const base = normalized.split("-")[0];
+  return SUPPORTED_LOCALES.includes(base as Locale) ? (base as Locale) : undefined;
+}
+
+export function resolveDefaultLocale(
+  configuredDefault: string | undefined,
+  runtimeLocale: string | undefined,
+  storage?: LocaleStorage,
+): Locale {
+  const saved = getSavedLocalePreference(storage);
+  if (saved) return saved;
+  const configured = normalizeLocaleTag(configuredDefault);
+  if (configured) return configured;
+  const runtime = normalizeLocaleTag(runtimeLocale);
+  if (runtime) return runtime;
+  return "fr";
+}
+
+function getDefaultStorage(): LocaleStorage | undefined {
+  if (typeof window !== "undefined" && window.localStorage) {
+    return window.localStorage;
+  }
+  if (typeof globalThis !== "undefined" && "localStorage" in globalThis) {
+    return (globalThis as { localStorage?: LocaleStorage }).localStorage;
+  }
+  return undefined;
+}
+
+export function getSavedLocalePreference(storage: LocaleStorage | undefined = getDefaultStorage()): Locale | undefined {
+  try {
+    const raw = storage?.getItem(UI_LOCALE_STORAGE_KEY) ?? undefined;
+    return normalizeLocaleTag(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+export function setSavedLocalePreference(
+  locale: Locale,
+  storage: LocaleStorage | undefined = getDefaultStorage(),
+): void {
+  try {
+    storage?.setItem(UI_LOCALE_STORAGE_KEY, locale);
+  } catch {
+    // Ignore storage write failures.
+  }
+}
+
+export function clearSavedLocalePreference(storage: LocaleStorage | undefined = getDefaultStorage()): void {
+  try {
+    storage?.removeItem(UI_LOCALE_STORAGE_KEY);
+  } catch {
+    // Ignore storage remove failures.
+  }
+}
+
+const MESSAGES = {
+  en: {
+    "app.subtitle": "Offline-first dictionary",
+    "locale.selectorLabel": "Language",
+    "locale.french": "Français",
+    "locale.english": "English",
+    "search.title": "Search",
+    "search.subtitle": "Dictionary-first experience. Install a dictionary if needed, then search.",
+    "firstRun.install": "Install dictionary",
+    "firstRun.retryInstall": "Retry install",
+    "activeDictionary.none": "No active dictionary",
+    "manage.open": "Manage dictionaries",
+    "search.queryLabel": "Query ({direction})",
+    "search.placeholder": "Type a {language} word…",
+    "manage.summary": "Manage dictionaries",
+    "manage.title": "Manage dictionaries",
+    "manage.installedLabel": "Installed dictionaries",
+    "manage.noneInstalled": "No dictionaries installed",
+    "manage.noInstalledMetadata": "No installed bundle metadata yet.",
+    "manage.status.installedBundles": "Installed bundles: {count}",
+    "manage.status.activeBundle": "Active bundle: {name}",
+    "manage.status.knownPayloadTotal": "Known payload total: {value}",
+    "manage.status.browserStorageUsage": "Browser storage usage: {usage} / {quota}",
+    "manage.status.sizeMetadataMissing": "Size metadata missing for {count} installed bundle(s).",
+    "advancedSetup.summary": "Advanced setup",
+    "catalog.urlLabel": "Catalog URL",
+    "catalog.urlPlaceholder": "https://example.org/catalog.json or /catalog.json",
+    "catalog.load": "Load catalog",
+    "import.installFiles": "Install bundle files",
+    "import.cancel": "Cancel install",
+    "db.delete": "Delete database",
+    "diagnostics.summary": "Advanced diagnostics",
+    "diagnostics.title": "Validation diagnostics",
+    "logging.label": "Validation logging",
+    "logging.off": "Off",
+    "logging.on": "On",
+    "logging.turnOn": "Turn On",
+    "logging.turnOff": "Turn Off",
+    "logging.export": "Export logs",
+    "logging.clear": "Clear logs",
+    "logging.localOnly": "Logs stay on this device. No automatic upload.",
+    "logging.recentTitle": "Recent query logs (debug)",
+    "logging.offNote": "Logging is off.",
+    "logging.refresh": "Refresh",
+    "dev.summary": "Developer tools",
+    "dev.gatingTitle": "Bundle manifest gating",
+    "dev.gatingSubtitle": "Select bundle.manifest.json and validate it before any import.",
+    "dev.recordsLabel": "records.jsonl (enriched)",
+    "dev.validateManifest": "Validate manifest + selected files",
+    "dev.importBundle": "Import bundle",
+    "dev.probeTitle": "Bundle size & memory probe",
+    "dev.probeSubtitle": "Select the bundle JSONL files from disk and run a parse probe.",
+    "dev.probeRecords": "Probe records",
+    "dev.probeIndex": "Probe index",
+    "dev.probeBoth": "Probe both",
+    "language.source": "Source",
+    "language.target": "Target",
+    "catalog.badge.active": "Active",
+    "catalog.badge.updateAvailable": "Update available",
+    "catalog.badge.installed": "Installed",
+    "catalog.badge.available": "Available",
+    "catalog.meta.version": "Version {value}",
+    "catalog.meta.records": "{count} records",
+    "catalog.meta.indexEntries": "{count} index entries",
+    "catalog.meta.hash": "Hash {value}",
+    "catalog.meta.bundleSource": "Bundle source: {value}",
+    "catalog.meta.manifest": "Manifest: {value}",
+    "catalog.meta.recordsFile": "Records: {value}",
+    "catalog.meta.indexFile": "Index: {value}",
+    "catalog.meta.sourceBase": "Source base: {value}",
+    "catalog.note.installed": "Installed: {value}",
+    "catalog.note.storageScope": "Storage scope: {value}",
+    "catalog.note.normalizationSchema": "Normalization: {normalization} | Schema: {schema}",
+    "catalog.note.installedHash": "Installed hash: {value}",
+    "catalog.note.catalogHash": "Catalog hash: {value}",
+    "catalog.note.activeInstalledVersion": "Installed version is active on this device.",
+    "catalog.note.installedVersionDiffers": "Installed version differs from catalog hash.",
+    "catalog.note.catalogVersion": "Catalog version {value}",
+    "catalog.action.update": "Update",
+    "catalog.action.use": "Use",
+    "catalog.action.remove": "Remove",
+    "catalog.action.useInstalled": "Use installed",
+    "catalog.action.install": "Install",
+    "catalog.empty": "No catalog loaded.",
+    "bundle.activeSet": "Active bundle set: {bundleId}\n",
+    "bundle.removed": "Removed bundle: {bundleId}\n",
+    "bundle.removeConfirm": "Remove installed bundle {bundleId} from this device?",
+    "activeDictionary.usingReady": "Using: {name} — ready to search",
+    "status.noActiveSelection":
+      "Installed bundles are present, but no active bundle is selected.\nChoose a dictionary from the selector or installed-bundles list to enable search.\n",
+    "status.partialDataWarning":
+      "Warning: partial data from a failed or interrupted import.\nNo active bundle. Search is disabled.\nDelete the database and re-import.\n",
+    "import.validatingManifest": "Validating manifest...\n",
+    "import.manifestValidationFailed": "Manifest validation failed:\n",
+    "import.missingRequiredFiles": "Missing required files: {files}\n\n",
+    "import.selectAllThreeFiles":
+      "Select all 3 bundle files:\n  bundle.manifest.json\n  records.jsonl\n  search_index.jsonl",
+    "import.fileValidationFailedFor": "File validation failed for {bundleId}:\n",
+    "import.bundleAlreadyInstalledMarkedActive": "Bundle already installed. Marked active: {bundleId}\n",
+    "import.updatingBundle": "Updating installed bundle {bundleId}.\n",
+    "import.existingHash": "Existing hash: {hash}\n",
+    "import.newHash": "New hash: {hash}\n",
+    "import.updatedBundleRemainActive": "Updated bundle will remain active.\n",
+    "import.currentActiveRemainUnchanged": "Current active bundle will remain unchanged.\n",
+    "import.installingBundle": "Installing {bundleId}...\n",
+    "import.installComplete":
+      "Install complete: {bundleId}\n{records} records, {indexEntries} index entries\n{elapsed} ms\n",
+    "import.importFailed": "\nImport failed: {error}\n",
+    "import.partialRemovedReimport": "Partial bundle data removed. Re-import required.\n",
+    "catalog.loading": "Loading catalog from {url}...\n",
+    "catalog.loaded":
+      "Catalog loaded.\nSource: {source}\nBundles: {count}\nFetched at: {fetchedAt}\nRemote policy: https anywhere; http only for same-origin or local hubs (localhost, .local, private IPs).\nBundle URL contract: url_base + bundle.manifest.json / records.jsonl / search_index.jsonl\n",
+    "catalog.loadFailed": "Catalog load failed: {error}\n",
+    "catalog.showingCachedFrom": "Showing cached catalog from {url}\nFetched at: {fetchedAt}\n",
+    "catalog.cachedRestored":
+      "Cached catalog restored.\nSource: {source}\nFetched at: {fetchedAt}\nLoad catalog to refresh from the network.\n",
+    "catalog.warnPrefix": "WARN: {warning}\n",
+    "featured.noEntryFound": "No featured dictionary entry found in catalog",
+    "catalog.missingSourceUrl": "No catalog source URL is available for this entry.\n",
+    "catalog.prepareRemoteInstall": "Preparing remote install for {bundleId}...\n",
+    "catalog.remoteInstallComplete":
+      "Remote install complete: {bundleId}\n{records} records, {indexEntries} index entries\n{elapsed} ms\n",
+    "catalog.installFailedHeader": "Install FAILED\n",
+    "progress.installingPrefix": "Installing",
+    "progress.stageLabel": "Stage",
+    "progress.stage.fetchManifest": "fetching manifest",
+    "progress.stage.fetchRecords": "fetching records.jsonl",
+    "progress.stage.fetchSearchIndex": "fetching search_index.jsonl",
+    "progress.stage.stagingPayloads": "staging payloads",
+    "progress.bytesReadLabel": "bytes read",
+    "progress.linesSeenLabel": "lines seen",
+    "progress.recordsWrittenLabel": "records written",
+    "progress.entriesWrittenLabel": "entries written",
+    "progress.batchesCommittedLabel": "batches committed",
+    "db.deleting": "Deleting database...\n",
+    "db.deleted": "Database deleted.\n",
+    "db.deleteFailed": "Delete failed: {error}\n",
+    "status.dictionaryReady": "Dictionary ready for offline search.",
+    "status.noActiveDictionaryInstalled": "No active dictionary installed yet.",
+    "status.noActiveBundle": "No active bundle.\n",
+    "status.dbError": "Database error: {error}\n",
+    "firstRun.offlineNoDictionary":
+      "No dictionary installed and you appear to be offline.\nConnect and retry featured install, or use Manage dictionaries → Advanced setup.",
+    "firstRun.onlinePrompt":
+      "Install the deployment-configured featured dictionary to start searching.\nAdvanced setup is available for custom catalogs and manual import.",
+    "featured.installStarted": "Install started.\n",
+    "featured.downloading": "Downloading/preparing dictionary...\n",
+    "featured.installed":
+      "Installed and ready to search.\nManage dictionaries and advanced setup remain available from Manage dictionaries.",
+    "featured.installFailed":
+      "Install failed.\n{error}\nRetry install or open Manage dictionaries → Advanced setup for recovery.",
+    "logging.noLogsYet": "No logs yet.",
+    "logging.recentLogsError": "Recent logs error: {error}",
+    "search.disabledBusy": "Search temporarily unavailable during install/update.",
+    "search.disabledNoActiveBundle": "Search disabled: no active bundle.",
+    "search.noMatch": "Query: \"{query}\" — No matches (all 4 levels checked). {elapsed} ms",
+    "search.resultMeta":
+      "Query: \"{query}\" — {count} result(s) at level: {level} [key: \"{key}\"] {elapsed} ms",
+    "search.error": "Search error: {error}",
+    "render.noTranslation": "(no translation available)",
+    "render.kindLexicon": "lexicon",
+    "render.kindIndex": "index",
+    "entry.back": "← Back to results",
+    "entry.targetEntriesDefault": "Target entries:",
+    "entry.targetEntries": "{label} entries:",
+    "entry.noDisplay": "No display data for ir_id: {id}",
+    "entry.usage": "Usage: {value}",
+    "entry.synShort": "Syn: {value}",
+    "entry.variants": "Variants: {value}",
+    "entry.synonyms": "Synonyms: {value}",
+    "entry.etymology": "Etymology: {value}",
+    "entry.literal": "Literal: {value}",
+    "entry.meta.irId": "ir_id: {value}",
+    "entry.meta.source": "source: {value}",
+    "entry.meta.norm": "norm: {value}",
+    "entry.meta.corpus": "corpus: {value}",
+    "queryLogs.clearConfirm": "Clear all local query logs from this device?",
+    "queryLogs.noLogsToExport": "No logs to export.",
+    "queryLogs.clearCancelled": "Clear cancelled.",
+    "queryLogs.cleared": "Cleared query logs.",
+    "queryLogs.count.one": "1 log",
+    "queryLogs.count.many": "{count} logs",
+    "queryLogs.countError": "Log count error: {error}",
+    "queryLogs.exported.one": "Exported 1 log.",
+    "queryLogs.exported.many": "Exported {count} logs.",
+    "queryLogs.exportFailed": "Export failed: {error}",
+    "queryLogs.clearFailed": "Clear failed: {error}",
+  },
+  fr: {
+    "app.subtitle": "Dictionnaire hors ligne d'abord",
+    "locale.selectorLabel": "Langue",
+    "locale.french": "Français",
+    "locale.english": "English",
+    "search.title": "Recherche",
+    "search.subtitle": "Expérience dictionnaire d'abord. Installez un dictionnaire si nécessaire, puis recherchez.",
+    "firstRun.install": "Installer le dictionnaire",
+    "firstRun.retryInstall": "Réessayer l'installation",
+    "activeDictionary.none": "Aucun dictionnaire actif",
+    "manage.open": "Gérer les dictionnaires",
+    "search.queryLabel": "Requête ({direction})",
+    "search.placeholder": "Saisissez un mot en {language}…",
+    "manage.summary": "Gérer les dictionnaires",
+    "manage.title": "Gérer les dictionnaires",
+    "manage.installedLabel": "Dictionnaires installés",
+    "manage.noneInstalled": "Aucun dictionnaire installé",
+    "manage.noInstalledMetadata": "Aucune métadonnée de bundle installée pour le moment.",
+    "manage.status.installedBundles": "Bundles installés : {count}",
+    "manage.status.activeBundle": "Bundle actif : {name}",
+    "manage.status.knownPayloadTotal": "Total de charge utile connue : {value}",
+    "manage.status.browserStorageUsage": "Utilisation du stockage navigateur : {usage} / {quota}",
+    "manage.status.sizeMetadataMissing": "Métadonnées de taille manquantes pour {count} bundle(s) installé(s).",
+    "advancedSetup.summary": "Configuration avancée",
+    "catalog.urlLabel": "URL du catalogue",
+    "catalog.urlPlaceholder": "https://example.org/catalog.json ou /catalog.json",
+    "catalog.load": "Charger le catalogue",
+    "import.installFiles": "Installer les fichiers du bundle",
+    "import.cancel": "Annuler l'installation",
+    "db.delete": "Supprimer la base de données",
+    "diagnostics.summary": "Diagnostics avancés",
+    "diagnostics.title": "Diagnostics de validation",
+    "logging.label": "Journalisation de validation",
+    "logging.off": "Désactivée",
+    "logging.on": "Activée",
+    "logging.turnOn": "Activer",
+    "logging.turnOff": "Désactiver",
+    "logging.export": "Exporter les journaux",
+    "logging.clear": "Effacer les journaux",
+    "logging.localOnly": "Les journaux restent sur cet appareil. Aucun envoi automatique.",
+    "logging.recentTitle": "Journaux de requête récents (debug)",
+    "logging.offNote": "La journalisation est désactivée.",
+    "logging.refresh": "Actualiser",
+    "dev.summary": "Outils développeur",
+    "dev.gatingTitle": "Validation du manifeste de bundle",
+    "dev.gatingSubtitle": "Sélectionnez bundle.manifest.json et validez-le avant tout import.",
+    "dev.recordsLabel": "records.jsonl (enrichi)",
+    "dev.validateManifest": "Valider le manifeste + les fichiers sélectionnés",
+    "dev.importBundle": "Importer le bundle",
+    "dev.probeTitle": "Sonde de taille de bundle et mémoire",
+    "dev.probeSubtitle": "Sélectionnez les fichiers JSONL du bundle puis lancez la sonde.",
+    "dev.probeRecords": "Sonder records",
+    "dev.probeIndex": "Sonder index",
+    "dev.probeBoth": "Sonder les deux",
+    "language.source": "Source",
+    "language.target": "Cible",
+    "catalog.badge.active": "Actif",
+    "catalog.badge.updateAvailable": "Mise à jour disponible",
+    "catalog.badge.installed": "Installé",
+    "catalog.badge.available": "Disponible",
+    "catalog.meta.version": "Version {value}",
+    "catalog.meta.records": "{count} enregistrements",
+    "catalog.meta.indexEntries": "{count} entrées d'index",
+    "catalog.meta.hash": "Empreinte {value}",
+    "catalog.meta.bundleSource": "Source du bundle : {value}",
+    "catalog.meta.manifest": "Manifeste : {value}",
+    "catalog.meta.recordsFile": "Records : {value}",
+    "catalog.meta.indexFile": "Index : {value}",
+    "catalog.meta.sourceBase": "Base source : {value}",
+    "catalog.note.installed": "Installé : {value}",
+    "catalog.note.storageScope": "Portée de stockage : {value}",
+    "catalog.note.normalizationSchema": "Normalisation : {normalization} | Schéma : {schema}",
+    "catalog.note.installedHash": "Empreinte installée : {value}",
+    "catalog.note.catalogHash": "Empreinte du catalogue : {value}",
+    "catalog.note.activeInstalledVersion": "La version installée est active sur cet appareil.",
+    "catalog.note.installedVersionDiffers": "La version installée diffère de l'empreinte du catalogue.",
+    "catalog.note.catalogVersion": "Version du catalogue {value}",
+    "catalog.action.update": "Mettre à jour",
+    "catalog.action.use": "Utiliser",
+    "catalog.action.remove": "Supprimer",
+    "catalog.action.useInstalled": "Utiliser l'installé",
+    "catalog.action.install": "Installer",
+    "catalog.empty": "Aucun catalogue chargé.",
+    "bundle.activeSet": "Bundle actif défini : {bundleId}\n",
+    "bundle.removed": "Bundle supprimé : {bundleId}\n",
+    "bundle.removeConfirm": "Supprimer le bundle installé {bundleId} de cet appareil ?",
+    "activeDictionary.usingReady": "Utilisation : {name} — prêt pour la recherche",
+    "status.noActiveSelection":
+      "Des bundles installés sont présents, mais aucun bundle actif n'est sélectionné.\nChoisissez un dictionnaire dans le sélecteur ou la liste des bundles installés pour activer la recherche.\n",
+    "status.partialDataWarning":
+      "Avertissement : données partielles issues d'un import échoué ou interrompu.\nAucun bundle actif. La recherche est désactivée.\nSupprimez la base de données puis réimportez.\n",
+    "import.validatingManifest": "Validation du manifeste...\n",
+    "import.manifestValidationFailed": "Échec de validation du manifeste :\n",
+    "import.missingRequiredFiles": "Fichiers requis manquants : {files}\n\n",
+    "import.selectAllThreeFiles":
+      "Sélectionnez les 3 fichiers du bundle :\n  bundle.manifest.json\n  records.jsonl\n  search_index.jsonl",
+    "import.fileValidationFailedFor": "Échec de validation des fichiers pour {bundleId} :\n",
+    "import.bundleAlreadyInstalledMarkedActive": "Bundle déjà installé. Marqué actif : {bundleId}\n",
+    "import.updatingBundle": "Mise à jour du bundle installé {bundleId}.\n",
+    "import.existingHash": "Empreinte existante : {hash}\n",
+    "import.newHash": "Nouvelle empreinte : {hash}\n",
+    "import.updatedBundleRemainActive": "Le bundle mis à jour restera actif.\n",
+    "import.currentActiveRemainUnchanged": "Le bundle actif actuel restera inchangé.\n",
+    "import.installingBundle": "Installation de {bundleId}...\n",
+    "import.installComplete":
+      "Installation terminée : {bundleId}\n{records} enregistrements, {indexEntries} entrées d'index\n{elapsed} ms\n",
+    "import.importFailed": "\nÉchec d'import : {error}\n",
+    "import.partialRemovedReimport": "Les données partielles du bundle ont été supprimées. Réimport requis.\n",
+    "catalog.loading": "Chargement du catalogue depuis {url}...\n",
+    "catalog.loaded":
+      "Catalogue chargé.\nSource : {source}\nBundles : {count}\nRécupéré à : {fetchedAt}\nPolitique distante : https partout ; http uniquement en même origine ou hubs locaux (localhost, .local, IP privées).\nContrat URL bundle : url_base + bundle.manifest.json / records.jsonl / search_index.jsonl\n",
+    "catalog.loadFailed": "Échec du chargement du catalogue : {error}\n",
+    "catalog.showingCachedFrom": "Affichage du catalogue en cache depuis {url}\nRécupéré à : {fetchedAt}\n",
+    "catalog.cachedRestored":
+      "Catalogue en cache restauré.\nSource : {source}\nRécupéré à : {fetchedAt}\nChargez le catalogue pour actualiser depuis le réseau.\n",
+    "catalog.warnPrefix": "WARN : {warning}\n",
+    "featured.noEntryFound": "Aucune entrée de dictionnaire en vedette trouvée dans le catalogue",
+    "catalog.missingSourceUrl": "Aucune URL source de catalogue disponible pour cette entrée.\n",
+    "catalog.prepareRemoteInstall": "Préparation de l'installation distante pour {bundleId}...\n",
+    "catalog.remoteInstallComplete":
+      "Installation distante terminée : {bundleId}\n{records} enregistrements, {indexEntries} entrées d'index\n{elapsed} ms\n",
+    "catalog.installFailedHeader": "ÉCHEC D'INSTALLATION\n",
+    "progress.installingPrefix": "Installation de",
+    "progress.stageLabel": "Étape",
+    "progress.stage.fetchManifest": "récupération du manifeste",
+    "progress.stage.fetchRecords": "récupération de records.jsonl",
+    "progress.stage.fetchSearchIndex": "récupération de search_index.jsonl",
+    "progress.stage.stagingPayloads": "préparation des données",
+    "progress.bytesReadLabel": "octets lus",
+    "progress.linesSeenLabel": "lignes vues",
+    "progress.recordsWrittenLabel": "enregistrements écrits",
+    "progress.entriesWrittenLabel": "entrées écrites",
+    "progress.batchesCommittedLabel": "lots validés",
+    "db.deleting": "Suppression de la base de données...\n",
+    "db.deleted": "Base de données supprimée.\n",
+    "db.deleteFailed": "Échec de suppression : {error}\n",
+    "status.dictionaryReady": "Dictionnaire prêt pour la recherche hors ligne.",
+    "status.noActiveDictionaryInstalled": "Aucun dictionnaire actif installé pour le moment.",
+    "status.noActiveBundle": "Aucun bundle actif.\n",
+    "status.dbError": "Erreur de base de données : {error}\n",
+    "firstRun.offlineNoDictionary":
+      "Aucun dictionnaire installé et vous semblez hors ligne.\nConnectez-vous puis réessayez l'installation en vedette, ou utilisez Gérer les dictionnaires → Configuration avancée.",
+    "firstRun.onlinePrompt":
+      "Installez le dictionnaire en vedette configuré pour ce déploiement afin de commencer la recherche.\nLa configuration avancée reste disponible pour les catalogues personnalisés et l'import manuel.",
+    "featured.installStarted": "Installation démarrée.\n",
+    "featured.downloading": "Téléchargement/préparation du dictionnaire...\n",
+    "featured.installed":
+      "Installé et prêt pour la recherche.\nGérer les dictionnaires et la configuration avancée restent disponibles depuis Gérer les dictionnaires.",
+    "featured.installFailed":
+      "Échec de l'installation.\n{error}\nRéessayez l'installation ou ouvrez Gérer les dictionnaires → Configuration avancée pour récupérer.",
+    "logging.noLogsYet": "Aucun journal pour le moment.",
+    "logging.recentLogsError": "Erreur des journaux récents : {error}",
+    "search.disabledBusy": "Recherche temporairement indisponible pendant l'installation/mise à jour.",
+    "search.disabledNoActiveBundle": "Recherche désactivée : aucun bundle actif.",
+    "search.noMatch": "Requête : \"{query}\" — Aucun résultat (4 niveaux vérifiés). {elapsed} ms",
+    "search.resultMeta":
+      "Requête : \"{query}\" — {count} résultat(s) au niveau : {level} [clé : \"{key}\"] {elapsed} ms",
+    "search.error": "Erreur de recherche : {error}",
+    "render.noTranslation": "(pas de traduction disponible)",
+    "render.kindLexicon": "lexique",
+    "render.kindIndex": "index",
+    "entry.back": "← Retour aux résultats",
+    "entry.targetEntriesDefault": "Entrées cibles :",
+    "entry.targetEntries": "Entrées {label} :",
+    "entry.noDisplay": "Aucune donnée d'affichage pour ir_id : {id}",
+    "entry.usage": "Usage : {value}",
+    "entry.synShort": "Syn. : {value}",
+    "entry.variants": "Variantes : {value}",
+    "entry.synonyms": "Synonymes : {value}",
+    "entry.etymology": "Étymologie : {value}",
+    "entry.literal": "Sens littéral : {value}",
+    "entry.meta.irId": "ir_id : {value}",
+    "entry.meta.source": "source : {value}",
+    "entry.meta.norm": "norme : {value}",
+    "entry.meta.corpus": "corpus : {value}",
+    "queryLogs.clearConfirm": "Effacer tous les journaux de requête locaux de cet appareil ?",
+    "queryLogs.noLogsToExport": "Aucun journal à exporter.",
+    "queryLogs.clearCancelled": "Effacement annulé.",
+    "queryLogs.cleared": "Journaux de requête effacés.",
+    "queryLogs.count.one": "1 journal",
+    "queryLogs.count.many": "{count} journaux",
+    "queryLogs.countError": "Erreur de comptage des journaux : {error}",
+    "queryLogs.exported.one": "1 journal exporté.",
+    "queryLogs.exported.many": "{count} journaux exportés.",
+    "queryLogs.exportFailed": "Échec d'export : {error}",
+    "queryLogs.clearFailed": "Échec d'effacement : {error}",
+  },
+} as const;
+
+export type TranslationKey = keyof (typeof MESSAGES)["en"];
+
+let currentLocale: Locale = "fr";
+
+export function setCurrentLocale(locale: Locale): void {
+  currentLocale = locale;
+}
+
+export function setCurrentLocaleWithPersistence(
+  locale: Locale,
+  storage?: LocaleStorage,
+): void {
+  setCurrentLocale(locale);
+  setSavedLocalePreference(locale, storage);
+}
+
+export function getCurrentLocale(): Locale {
+  return currentLocale;
+}
+
+function interpolate(template: string, vars: Record<string, string | number>): string {
+  return template.replaceAll(/\{([a-zA-Z0-9_]+)\}/g, (_, name: string) => {
+    if (!Object.hasOwn(vars, name)) return `{${name}}`;
+    return String(vars[name]);
+  });
+}
+
+export function t(key: TranslationKey, vars?: Record<string, string | number>): string {
+  const fromLocale = MESSAGES[currentLocale][key];
+  const fallback = MESSAGES.en[key];
+  const template = fromLocale ?? fallback ?? key;
+  return vars ? interpolate(template, vars) : template;
+}
+

--- a/web/src/install/bundle_install.ts
+++ b/web/src/install/bundle_install.ts
@@ -52,6 +52,7 @@ export type InstallRemoteBundleOptions = {
   onUpdate?: (message: string) => void;
   storageEstimate?: () => Promise<{ usage?: number; quota?: number }>;
   activateOnCommit?: boolean;
+  progressCopy?: Partial<InstallProgressCopy>;
 };
 
 export type InstallBundleMetadata = {
@@ -59,6 +60,42 @@ export type InstallBundleMetadata = {
   version?: string;
   storageBytes?: number;
 };
+
+export type InstallProgressCopy = {
+  installingPrefix: string;
+  stageLabel: string;
+  stageFetchingManifest: string;
+  stageFetchingRecords: string;
+  stageFetchingSearchIndex: string;
+  stageStagingPayloads: string;
+  bytesReadLabel: string;
+  linesSeenLabel: string;
+  recordsWrittenLabel: string;
+  entriesWrittenLabel: string;
+  batchesCommittedLabel: string;
+};
+
+const DEFAULT_INSTALL_PROGRESS_COPY: InstallProgressCopy = {
+  installingPrefix: "Installing",
+  stageLabel: "Stage",
+  stageFetchingManifest: "fetching manifest",
+  stageFetchingRecords: "fetching records.jsonl",
+  stageFetchingSearchIndex: "fetching search_index.jsonl",
+  stageStagingPayloads: "staging payloads",
+  bytesReadLabel: "bytes read",
+  linesSeenLabel: "lines seen",
+  recordsWrittenLabel: "records written",
+  entriesWrittenLabel: "entries written",
+  batchesCommittedLabel: "batches committed",
+};
+
+function buildProgressCopy(override?: Partial<InstallProgressCopy>): InstallProgressCopy {
+  return { ...DEFAULT_INSTALL_PROGRESS_COPY, ...override };
+}
+
+function installHeader(copy: InstallProgressCopy, bundleId: string): string {
+  return `${copy.installingPrefix} ${bundleId}`;
+}
 
 function createLinkedAbortSignal(timeoutMs: number, externalSignal?: AbortSignal): {
   signal: AbortSignal;
@@ -217,7 +254,9 @@ export async function installBundleIntoDb(
   signal?: AbortSignal,
   metadata?: InstallBundleMetadata,
   activateOnCommit = true,
+  progressCopyOverride?: Partial<InstallProgressCopy>,
 ): Promise<InstallBundleResult> {
+  const progressCopy = buildProgressCopy(progressCopyOverride);
   const recovered = await recoverInterruptedBundleInstall(db);
   if (recovered) {
     onUpdate(`${recovered}\n`);
@@ -256,13 +295,13 @@ export async function installBundleIntoDb(
       signal,
       onProgress: (p: ImportRecordsProgress) => {
         onUpdate(
-          `Installing ${manifest.bundle_id}\n` +
-            `Stage: staging payloads\n\n` +
+          `${installHeader(progressCopy, manifest.bundle_id)}\n` +
+            `${progressCopy.stageLabel}: ${progressCopy.stageStagingPayloads}\n\n` +
             `[records.jsonl]\n` +
-            `bytes read: ${p.bytesRead}\n` +
-            `lines seen: ${p.linesSeen}\n` +
-            `records written: ${p.recordsWritten}\n` +
-            `batches committed: ${p.batchesCommitted}\n`,
+            `${progressCopy.bytesReadLabel}: ${p.bytesRead}\n` +
+            `${progressCopy.linesSeenLabel}: ${p.linesSeen}\n` +
+            `${progressCopy.recordsWrittenLabel}: ${p.recordsWritten}\n` +
+            `${progressCopy.batchesCommittedLabel}: ${p.batchesCommitted}\n`,
         );
       },
     });
@@ -275,14 +314,14 @@ export async function installBundleIntoDb(
       signal,
       onProgress: (p: ImportSearchIndexProgress) => {
         onUpdate(
-          `Installing ${manifest.bundle_id}\n` +
-            `Stage: staging payloads\n\n` +
-            `[records.jsonl] written: ${recordsCount}\n` +
+          `${installHeader(progressCopy, manifest.bundle_id)}\n` +
+            `${progressCopy.stageLabel}: ${progressCopy.stageStagingPayloads}\n\n` +
+            `[records.jsonl] ${progressCopy.recordsWrittenLabel}: ${recordsCount}\n` +
             `\n[search_index.jsonl]\n` +
-            `bytes read: ${p.bytesRead}\n` +
-            `lines seen: ${p.linesSeen}\n` +
-            `entries written: ${p.entriesWritten}\n` +
-            `batches committed: ${p.batchesCommitted}\n`,
+            `${progressCopy.bytesReadLabel}: ${p.bytesRead}\n` +
+            `${progressCopy.linesSeenLabel}: ${p.linesSeen}\n` +
+            `${progressCopy.entriesWrittenLabel}: ${p.entriesWritten}\n` +
+            `${progressCopy.batchesCommittedLabel}: ${p.batchesCommitted}\n`,
         );
       },
     });
@@ -337,13 +376,14 @@ export async function installRemoteCatalogBundle(
   catalogUrl: string,
   options: InstallRemoteBundleOptions = {},
 ): Promise<{ manifest: BundleManifestV1; result: InstallBundleResult }> {
+  const progressCopy = buildProgressCopy(options.progressCopy);
   const onUpdate = options.onUpdate ?? (() => undefined);
   const fetchImpl = options.fetchImpl ?? fetch;
   const responseStartTimeoutMs = options.timeoutMs ?? DEFAULT_BUNDLE_FETCH_START_TIMEOUT_MS;
   const signal = options.signal;
 
   const urls = deriveBundleAssetUrls(catalogUrl, entry);
-  onUpdate(`Installing ${entry.bundle_id}\nStage: fetching manifest\n`);
+  onUpdate(`${installHeader(progressCopy, entry.bundle_id)}\n${progressCopy.stageLabel}: ${progressCopy.stageFetchingManifest}\n`);
   const manifestTimeout = createLinkedAbortSignal(responseStartTimeoutMs, signal);
   let manifestResponse: Response;
   try {
@@ -413,7 +453,7 @@ export async function installRemoteCatalogBundle(
     }
   }
 
-  onUpdate(`Installing ${entry.bundle_id}\nStage: fetching records.jsonl\n`);
+  onUpdate(`${installHeader(progressCopy, entry.bundle_id)}\n${progressCopy.stageLabel}: ${progressCopy.stageFetchingRecords}\n`);
   const recordsStream = await fetchBodyStream(
     urls.records_url,
     recordsEntry.byte_length,
@@ -422,7 +462,7 @@ export async function installRemoteCatalogBundle(
     responseStartTimeoutMs,
     catalogUrl,
   );
-  onUpdate(`Installing ${entry.bundle_id}\nStage: fetching search_index.jsonl\n`);
+  onUpdate(`${installHeader(progressCopy, entry.bundle_id)}\n${progressCopy.stageLabel}: ${progressCopy.stageFetchingSearchIndex}\n`);
   const indexStream = await fetchBodyStream(
     urls.search_index_url,
     indexEntry.byte_length,
@@ -447,6 +487,7 @@ export async function installRemoteCatalogBundle(
       storageBytes: entry.size_bytes,
     },
     options.activateOnCommit ?? true,
+    progressCopy,
   );
 
   return { manifest, result };

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -51,6 +51,14 @@ import {
   exportQueryLogsFromUi,
   getQueryLogCountFromDb,
 } from "./query_logging/query_log_controls";
+import {
+  getCurrentLocale,
+  type Locale,
+  resolveDefaultLocale,
+  setCurrentLocale,
+  setCurrentLocaleWithPersistence,
+  t,
+} from "./i18n";
 import { queryLogHitMiss } from "./query_logging/query_log_inspect";
 import { listRecentQueryLogs } from "./query_logging/query_log_store";
 import {
@@ -72,6 +80,12 @@ if (!app) {
   throw new Error("Missing #app root");
 }
 
+const DEFAULT_LOCALE = resolveDefaultLocale(
+  import.meta.env.VITE_DEFAULT_LOCALE,
+  typeof navigator !== "undefined" ? navigator.language : undefined,
+);
+setCurrentLocale(DEFAULT_LOCALE);
+
 const FEATURED_CATALOG_URL =
   import.meta.env.VITE_FEATURED_CATALOG_URL?.trim() || "/catalog.json";
 const FEATURED_BUNDLE_ID = import.meta.env.VITE_FEATURED_BUNDLE_ID?.trim() || undefined;
@@ -79,35 +93,46 @@ const FEATURED_BUNDLE_ID = import.meta.env.VITE_FEATURED_BUNDLE_ID?.trim() || un
 app.innerHTML = `
   <div class="container">
     <div class="card">
-      <h1 class="title">SiraLex</h1>
-      <p class="subtitle">Offline-first dictionary</p>
+      <div class="row" style="align-items: start; justify-content: space-between; gap: 12px">
+        <div>
+          <h1 class="title">SiraLex</h1>
+          <p class="subtitle">${t("app.subtitle")}</p>
+        </div>
+        <div class="field locale-control">
+          <div class="label">${t("locale.selectorLabel")}</div>
+          <select id="localeSelect">
+            <option value="fr" ${DEFAULT_LOCALE === "fr" ? "selected" : ""}>${t("locale.french")}</option>
+            <option value="en" ${DEFAULT_LOCALE === "en" ? "selected" : ""}>${t("locale.english")}</option>
+          </select>
+        </div>
+      </div>
     </div>
 
     <div class="card" style="margin-top: 16px">
-      <h2 class="title" style="font-size: 16px; margin-bottom: 8px">Search</h2>
-      <p class="subtitle">Dictionary-first experience. Install a dictionary if needed, then search.</p>
+      <h2 class="title" style="font-size: 16px; margin-bottom: 8px">${t("search.title")}</h2>
+      <p class="subtitle">${t("search.subtitle")}</p>
       <div id="dictStatus" class="mono"></div>
       <div id="firstRun" style="display: none; margin-top: 12px; padding: 10px; border: 1px solid var(--border); border-radius: 8px">
         <div id="featuredInstallStatus" class="mono"></div>
         <div class="row" style="margin-top: 10px; gap: 8px">
-          <button id="featuredInstall" class="btn">Install dictionary</button>
-          <button id="retryFeaturedInstall" class="btn" style="display: none">Retry install</button>
+          <button id="featuredInstall" class="btn">${t("firstRun.install")}</button>
+          <button id="retryFeaturedInstall" class="btn" style="display: none">${t("firstRun.retryInstall")}</button>
         </div>
       </div>
 
       <div id="activeDictionaryRow" style="margin-top: 12px; padding: 10px; border: 1px solid var(--border); border-radius: 8px">
         <div class="row" style="align-items: center; justify-content: space-between; gap: 8px">
-          <div class="mono" id="activeDictionarySummary">No active dictionary</div>
-          <button id="openManageDictionaries" class="btn" type="button">Manage dictionaries</button>
+          <div class="mono" id="activeDictionarySummary">${t("activeDictionary.none")}</div>
+          <button id="openManageDictionaries" class="btn" type="button">${t("manage.open")}</button>
         </div>
       </div>
 
       <div class="row" style="margin-top: 12px; align-items: center">
         <div class="field" style="flex: 1">
-          <div class="label" id="searchLabel">Query (Source → Target)</div>
-          <input id="searchInput" type="text" placeholder="Type a Source word…" disabled autocomplete="off" />
+          <div class="label" id="searchLabel">${t("search.queryLabel", { direction: `${t("language.source")} → ${t("language.target")}` })}</div>
+          <input id="searchInput" type="text" placeholder="${t("search.placeholder", { language: t("language.source") })}" disabled autocomplete="off" />
         </div>
-        <button id="langToggle" class="btn" disabled>Source → Target</button>
+        <button id="langToggle" class="btn" disabled>${t("language.source")} → ${t("language.target")}</button>
       </div>
 
       <div id="searchMeta" class="mono" style="margin-top: 12px"></div>
@@ -115,14 +140,14 @@ app.innerHTML = `
     </div>
 
     <details id="manageDictionariesPanel" style="margin-top: 16px">
-      <summary style="color: var(--muted); font-size: 13px; cursor: pointer; padding: 8px 0">Manage dictionaries</summary>
+      <summary style="color: var(--muted); font-size: 13px; cursor: pointer; padding: 8px 0">${t("manage.summary")}</summary>
       <div class="card" style="margin-top: 8px">
-        <h2 class="title" style="font-size: 16px; margin-bottom: 8px">Manage dictionaries</h2>
+        <h2 class="title" style="font-size: 16px; margin-bottom: 8px">${t("manage.title")}</h2>
         <div class="row" style="margin-top: 12px; align-items: center">
           <div class="field" style="flex: 1">
-            <div class="label">Installed dictionaries</div>
+            <div class="label">${t("manage.installedLabel")}</div>
             <select id="bundleSelect" disabled>
-              <option value="">No dictionaries installed</option>
+              <option value="">${t("manage.noneInstalled")}</option>
             </select>
           </div>
         </div>
@@ -130,56 +155,56 @@ app.innerHTML = `
         <div id="installedBundleList" style="margin-top: 12px"></div>
 
         <details style="margin-top: 12px">
-          <summary style="color: var(--muted); font-size: 13px; cursor: pointer">Advanced setup</summary>
+          <summary style="color: var(--muted); font-size: 13px; cursor: pointer">${t("advancedSetup.summary")}</summary>
           <div class="row" style="margin-top: 12px; align-items: end">
             <div class="field" style="flex: 1">
-              <div class="label">Catalog URL</div>
-              <input id="catalogUrl" type="text" placeholder="https://example.org/catalog.json or /catalog.json" autocomplete="off" />
+              <div class="label">${t("catalog.urlLabel")}</div>
+              <input id="catalogUrl" type="text" placeholder="${t("catalog.urlPlaceholder")}" autocomplete="off" />
             </div>
-            <button id="loadCatalog" class="btn">Load catalog</button>
+            <button id="loadCatalog" class="btn">${t("catalog.load")}</button>
           </div>
           <div id="catalogStatus" class="mono" style="margin-top: 12px"></div>
           <div id="catalogList" style="margin-top: 12px"></div>
           <div class="row" style="margin-top: 12px">
-            <button id="quickImport" class="btn">Install bundle files</button>
+            <button id="quickImport" class="btn">${t("import.installFiles")}</button>
             <input id="quickImportFiles" type="file" multiple style="display: none" />
-            <button id="cancelInstall" class="btn" style="display: none">Cancel install</button>
+            <button id="cancelInstall" class="btn" style="display: none">${t("import.cancel")}</button>
           </div>
         </details>
 
         <div id="importProgress" class="mono" style="margin-top: 12px; display: none"></div>
         <div class="row" style="margin-top: 12px">
-          <button id="clearDb" class="btn">Delete database</button>
+          <button id="clearDb" class="btn">${t("db.delete")}</button>
         </div>
       </div>
     </details>
 
     <details style="margin-top: 16px">
-      <summary style="color: var(--muted); font-size: 13px; cursor: pointer; padding: 8px 0">Advanced diagnostics</summary>
+      <summary style="color: var(--muted); font-size: 13px; cursor: pointer; padding: 8px 0">${t("diagnostics.summary")}</summary>
       <div class="card" style="margin-top: 8px">
-        <h2 class="title" style="font-size: 16px; margin-bottom: 8px">Validation diagnostics</h2>
+        <h2 class="title" style="font-size: 16px; margin-bottom: 8px">${t("diagnostics.title")}</h2>
         <div class="row" style="align-items: center; justify-content: space-between; gap: 12px">
           <div>
-            <div class="label">Validation logging</div>
-            <div id="queryLoggingStatus" class="mono">Off</div>
-            <div id="queryLoggingCount" class="mono" style="margin-top: 4px">0 logs</div>
+            <div class="label">${t("logging.label")}</div>
+            <div id="queryLoggingStatus" class="mono">${t("logging.off")}</div>
+            <div id="queryLoggingCount" class="mono" style="margin-top: 4px">${t("queryLogs.count.many", { count: 0 })}</div>
           </div>
-          <button id="queryLoggingToggle" class="btn" type="button">Turn On</button>
+          <button id="queryLoggingToggle" class="btn" type="button">${t("logging.turnOn")}</button>
         </div>
         <div class="row" style="margin-top: 8px; gap: 8px">
-          <button id="queryLogExport" class="btn" type="button">Export logs</button>
-          <button id="queryLogClear" class="btn" type="button">Clear logs</button>
+          <button id="queryLogExport" class="btn" type="button">${t("logging.export")}</button>
+          <button id="queryLogClear" class="btn" type="button">${t("logging.clear")}</button>
         </div>
         <p class="subtitle" style="margin: 8px 0 0 0">
-          Logs stay on this device. No automatic upload.
+          ${t("logging.localOnly")}
         </p>
         <div id="queryLogMessage" class="mono" style="margin-top: 8px"></div>
         <div style="margin-top: 12px">
-          <div class="label">Recent query logs (debug)</div>
-          <p id="recentQueryLogsOffNote" class="mono" style="margin: 8px 0 0 0; display: none">Logging is off.</p>
+          <div class="label">${t("logging.recentTitle")}</div>
+          <p id="recentQueryLogsOffNote" class="mono" style="margin: 8px 0 0 0; display: none">${t("logging.offNote")}</p>
           <div id="recentQueryLogsActive" style="display: none; margin-top: 8px">
             <div class="row" style="margin-bottom: 8px">
-              <button id="recentQueryLogsRefresh" class="btn" type="button">Refresh</button>
+              <button id="recentQueryLogsRefresh" class="btn" type="button">${t("logging.refresh")}</button>
             </div>
             <div id="recentQueryLogsTableHost"></div>
           </div>
@@ -188,12 +213,12 @@ app.innerHTML = `
     </details>
 
     <details style="margin-top: 16px">
-      <summary style="color: var(--muted); font-size: 13px; cursor: pointer; padding: 8px 0">Developer tools</summary>
+      <summary style="color: var(--muted); font-size: 13px; cursor: pointer; padding: 8px 0">${t("dev.summary")}</summary>
 
       <div class="card" style="margin-top: 8px">
-        <h3 class="title" style="font-size: 14px; margin-bottom: 8px">Bundle manifest gating</h3>
+        <h3 class="title" style="font-size: 14px; margin-bottom: 8px">${t("dev.gatingTitle")}</h3>
         <p class="subtitle">
-          Select <code>bundle.manifest.json</code> and validate it before any import.
+          ${t("dev.gatingSubtitle")}
         </p>
 
         <div class="row" style="margin-top: 12px">
@@ -205,7 +230,7 @@ app.innerHTML = `
 
         <div class="row" style="margin-top: 12px">
           <div class="field">
-            <div class="label">records.jsonl (enriched)</div>
+            <div class="label">${t("dev.recordsLabel")}</div>
             <input id="recordsFile" type="file" />
           </div>
           <div class="field">
@@ -215,8 +240,8 @@ app.innerHTML = `
         </div>
 
         <div class="row" style="margin-top: 12px">
-          <button id="validateManifest" class="btn" disabled>Validate manifest + selected files</button>
-          <button id="importBundle" class="btn" disabled>Import bundle</button>
+          <button id="validateManifest" class="btn" disabled>${t("dev.validateManifest")}</button>
+          <button id="importBundle" class="btn" disabled>${t("dev.importBundle")}</button>
         </div>
 
         <div id="manifestOut" class="mono" style="margin-top: 12px"></div>
@@ -224,15 +249,15 @@ app.innerHTML = `
       </div>
 
       <div class="card" style="margin-top: 8px">
-        <h3 class="title" style="font-size: 14px; margin-bottom: 8px">Bundle size &amp; memory probe</h3>
+        <h3 class="title" style="font-size: 14px; margin-bottom: 8px">${t("dev.probeTitle")}</h3>
         <p class="subtitle">
-          Select the bundle JSONL files from disk and run a parse probe.
+          ${t("dev.probeSubtitle")}
         </p>
 
         <div class="row" style="margin-top: 12px">
-          <button id="probeRecords" class="btn" disabled>Probe records</button>
-          <button id="probeIndex" class="btn" disabled>Probe index</button>
-          <button id="probeAll" class="btn" disabled>Probe both</button>
+          <button id="probeRecords" class="btn" disabled>${t("dev.probeRecords")}</button>
+          <button id="probeIndex" class="btn" disabled>${t("dev.probeIndex")}</button>
+          <button id="probeAll" class="btn" disabled>${t("dev.probeBoth")}</button>
         </div>
 
         <div id="probeOut" class="mono" style="margin-top: 12px"></div>
@@ -248,6 +273,7 @@ function mustGetEl<T extends Element>(selector: string): T {
 }
 
 // Primary UI elements
+const localeSelect = mustGetEl<HTMLSelectElement>("#localeSelect");
 const dictStatus = mustGetEl<HTMLDivElement>("#dictStatus");
 const activeDictionarySummary = mustGetEl<HTMLDivElement>("#activeDictionarySummary");
 const openManageDictionariesBtn = mustGetEl<HTMLButtonElement>("#openManageDictionaries");
@@ -351,7 +377,15 @@ function getManifestPayloadBytes(manifest: BundleManifestV1): number | undefined
 }
 
 function getInstalledBundleName(bundle: ActiveBundleMeta): string {
-  return bundle.display_name ?? getBundleDisplayName(bundle.bundle_id, bundle.language_meta);
+  return (
+    bundle.display_name ??
+    getBundleDisplayName(
+      bundle.bundle_id,
+      bundle.language_meta,
+      t("language.source"),
+      t("language.target"),
+    )
+  );
 }
 
 function formatInstalledAt(iso: string | undefined): string {
@@ -368,6 +402,14 @@ function getKnownBundlePayloadBytes(bundles: ActiveBundleMeta[]): number | undef
 
 function getLoadedCatalogEntry(bundleId: string): BundleCatalogEntryV1 | undefined {
   return loadedCatalogBundles.find((entry) => entry.bundle_id === bundleId);
+}
+
+function getLocalizedSourceLabel(meta?: ActiveBundleMeta["language_meta"]): string {
+  return getSourceLabel(meta, t("language.source"));
+}
+
+function getLocalizedTargetLabel(meta?: ActiveBundleMeta["language_meta"]): string {
+  return getTargetLabel(meta, t("language.target"));
 }
 
 function getCatalogEntryRuntimeState(entry: BundleCatalogEntryV1): {
@@ -392,20 +434,25 @@ function renderInstalledBundleManager() {
   const knownPayloadBytes = getKnownBundlePayloadBytes(installedBundles);
   const unknownSizeCount = installedBundles.filter((bundle) => bundle.storage_bytes === undefined).length;
   const statusLines = [
-    `Installed bundles: ${installedBundles.length}`,
-    `Active bundle: ${currentActiveBundle ? getInstalledBundleName(currentActiveBundle) : "none"}`,
-    `Known payload total: ${fmtBytes(knownPayloadBytes)}`,
-    `Browser storage usage: ${fmtBytes(currentStorageEstimate?.usage)} / ${fmtBytes(currentStorageEstimate?.quota)}`,
+    t("manage.status.installedBundles", { count: installedBundles.length }),
+    t("manage.status.activeBundle", {
+      name: currentActiveBundle ? getInstalledBundleName(currentActiveBundle) : "none",
+    }),
+    t("manage.status.knownPayloadTotal", { value: fmtBytes(knownPayloadBytes) }),
+    t("manage.status.browserStorageUsage", {
+      usage: fmtBytes(currentStorageEstimate?.usage),
+      quota: fmtBytes(currentStorageEstimate?.quota),
+    }),
   ];
   if (unknownSizeCount > 0) {
-    statusLines.push(`Size metadata missing for ${unknownSizeCount} installed bundle(s).`);
+    statusLines.push(t("manage.status.sizeMetadataMissing", { count: unknownSizeCount }));
   }
   installedBundleStatus.textContent = statusLines.join("\n");
 
   if (installedBundles.length === 0) {
     const empty = document.createElement("div");
     empty.className = "catalog-empty";
-    empty.textContent = "No installed bundle metadata yet.";
+    empty.textContent = t("manage.noInstalledMetadata");
     installedBundleList.appendChild(empty);
     return;
   }
@@ -438,30 +485,30 @@ function renderInstalledBundleManager() {
     if (isActive) {
       const activeBadge = document.createElement("span");
       activeBadge.className = "catalog-badge catalog-badge-active";
-      activeBadge.textContent = "Active";
+      activeBadge.textContent = t("catalog.badge.active");
       badges.appendChild(activeBadge);
     }
     if (updateAvailable) {
       const updateBadge = document.createElement("span");
       updateBadge.className = "catalog-badge catalog-badge-update";
-      updateBadge.textContent = "Update available";
+      updateBadge.textContent = t("catalog.badge.updateAvailable");
       badges.appendChild(updateBadge);
     } else if (!isActive) {
       const installedBadge = document.createElement("span");
       installedBadge.className = "catalog-badge catalog-badge-installed";
-      installedBadge.textContent = "Installed";
+      installedBadge.textContent = t("catalog.badge.installed");
       badges.appendChild(installedBadge);
     }
     header.append(titleBlock, badges);
 
     const meta = document.createElement("div");
     meta.className = "catalog-item-meta";
-    const labels = `${getSourceLabel(bundle.language_meta)} → ${getTargetLabel(bundle.language_meta)}`;
+    const labels = `${getLocalizedSourceLabel(bundle.language_meta)} → ${getLocalizedTargetLabel(bundle.language_meta)}`;
     const metaParts = [
-      bundle.version ? `Version ${bundle.version}` : undefined,
+      bundle.version ? t("catalog.meta.version", { value: bundle.version }) : undefined,
       labels,
-      `${bundle.records_count ?? "n/a"} records`,
-      `${bundle.index_entries_count ?? "n/a"} index entries`,
+      t("catalog.meta.records", { count: bundle.records_count ?? "n/a" }),
+      t("catalog.meta.indexEntries", { count: bundle.index_entries_count ?? "n/a" }),
       fmtBytes(bundle.storage_bytes),
     ].filter((part): part is string => part !== undefined);
     meta.textContent = metaParts.join(" | ");
@@ -469,13 +516,16 @@ function renderInstalledBundleManager() {
     const note = document.createElement("div");
     note.className = "catalog-item-note";
     note.textContent =
-      `Installed: ${formatInstalledAt(bundle.imported_at_iso)}\n` +
-      `Storage scope: ${getBundleStorageScopeId(bundle)}\n` +
-      `Normalization: ${bundle.normalization_ruleset} | Schema: ${bundle.record_schema_id}@${bundle.record_schema_version}`;
+      `${t("catalog.note.installed", { value: formatInstalledAt(bundle.imported_at_iso) })}\n` +
+      `${t("catalog.note.storageScope", { value: getBundleStorageScopeId(bundle) })}\n` +
+      t("catalog.note.normalizationSchema", {
+        normalization: bundle.normalization_ruleset,
+        schema: `${bundle.record_schema_id}@${bundle.record_schema_version}`,
+      });
     if (updateAvailable && catalogEntry) {
       note.textContent +=
-        `\nInstalled hash: ${bundle.expected_content_sha256 ?? "unknown"}` +
-        `\nCatalog hash: ${catalogEntry.content_sha256}`;
+        `\n${t("catalog.note.installedHash", { value: bundle.expected_content_sha256 ?? "unknown" })}` +
+        `\n${t("catalog.note.catalogHash", { value: catalogEntry.content_sha256 })}`;
     }
 
     const actions = document.createElement("div");
@@ -484,7 +534,7 @@ function renderInstalledBundleManager() {
     if (updateAvailable && catalogEntry) {
       const updateBtn = document.createElement("button");
       updateBtn.className = "btn";
-      updateBtn.textContent = "Update";
+      updateBtn.textContent = t("catalog.action.update");
       updateBtn.disabled = busy || !loadedCatalogUrl;
       updateBtn.addEventListener("click", () => {
         void withSingleWriterLock(`update bundle ${bundle.bundle_id}`, async () => {
@@ -496,7 +546,7 @@ function renderInstalledBundleManager() {
 
     const useBtn = document.createElement("button");
     useBtn.className = "btn";
-    useBtn.textContent = isActive ? "Active" : "Use";
+    useBtn.textContent = isActive ? t("catalog.badge.active") : t("catalog.action.use");
     useBtn.disabled = busy || isActive;
     useBtn.addEventListener("click", () => {
       void withSingleWriterLock(`switch active bundle ${bundle.bundle_id}`, async () => {
@@ -507,18 +557,18 @@ function renderInstalledBundleManager() {
           db.close();
         }
         importProgress.style.display = "";
-        importProgress.textContent = `Active bundle set: ${bundle.bundle_id}\n`;
+        importProgress.textContent = t("bundle.activeSet", { bundleId: bundle.bundle_id });
       });
     });
 
     const removeBtn = document.createElement("button");
     removeBtn.className = "btn";
-    removeBtn.textContent = "Remove";
+    removeBtn.textContent = t("catalog.action.remove");
     removeBtn.disabled = busy;
     removeBtn.addEventListener("click", () => {
       const confirmed =
         typeof window === "undefined" ||
-        window.confirm(`Remove installed bundle ${bundle.bundle_id} from this device?`);
+        window.confirm(t("bundle.removeConfirm", { bundleId: bundle.bundle_id }));
       if (!confirmed) return;
       void withSingleWriterLock(`remove bundle ${bundle.bundle_id}`, async () => {
         const db = await openSiralexDb();
@@ -528,7 +578,7 @@ function renderInstalledBundleManager() {
           db.close();
         }
         importProgress.style.display = "";
-        importProgress.textContent = `Removed bundle: ${bundle.bundle_id}\n`;
+        importProgress.textContent = t("bundle.removed", { bundleId: bundle.bundle_id });
       });
     });
 
@@ -626,6 +676,16 @@ updateCatalogControls();
 updateInstallControls();
 updateFeaturedInstallControls();
 
+localeSelect.addEventListener("change", () => {
+  const nextLocale = localeSelect.value;
+  if (nextLocale !== "fr" && nextLocale !== "en") return;
+  if (nextLocale === getCurrentLocale()) return;
+  setCurrentLocaleWithPersistence(nextLocale as Locale);
+  if (typeof window !== "undefined") {
+    window.location.reload();
+  }
+});
+
 openManageDictionariesBtn.addEventListener("click", () => {
   manageDictionariesPanel.open = true;
   manageDictionariesPanel.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -667,33 +727,35 @@ function getCatalogPresentationState(entry: BundleCatalogEntryV1): {
   if (comparison.state === "update_available") {
     return {
       badgeClass: "catalog-badge-update",
-      badgeLabel: "Update available",
-      note: isActive ? "Installed version is active on this device." : "Installed version differs from catalog hash.",
+      badgeLabel: t("catalog.badge.updateAvailable"),
+      note: isActive
+        ? t("catalog.note.activeInstalledVersion")
+        : t("catalog.note.installedVersionDiffers"),
     };
   }
 
   if (comparison.state === "installed_current") {
     return {
       badgeClass: isActive ? "catalog-badge-active" : "catalog-badge-installed",
-      badgeLabel: isActive ? "Active" : "Installed",
-      note: entry.version ? `Catalog version ${entry.version}` : undefined,
+      badgeLabel: isActive ? t("catalog.badge.active") : t("catalog.badge.installed"),
+      note: entry.version ? t("catalog.note.catalogVersion", { value: entry.version }) : undefined,
     };
   }
 
   return {
     badgeClass: "catalog-badge-available",
-    badgeLabel: "Available",
+    badgeLabel: t("catalog.badge.available"),
   };
 }
 
 function getCatalogActionLabel(entry: BundleCatalogEntryV1): string {
   const { comparison, isActive } = getCatalogEntryRuntimeState(entry);
   if (isActive && comparison.state === "installed_current") {
-    return "Active";
+    return t("catalog.badge.active");
   }
-  if (comparison.state === "update_available") return "Update";
-  if (comparison.state === "installed_current") return "Use installed";
-  return "Install";
+  if (comparison.state === "update_available") return t("catalog.action.update");
+  if (comparison.state === "installed_current") return t("catalog.action.useInstalled");
+  return t("catalog.action.install");
 }
 
 function renderCatalogList() {
@@ -702,7 +764,7 @@ function renderCatalogList() {
   if (loadedCatalogBundles.length === 0) {
     const empty = document.createElement("div");
     empty.className = "catalog-empty";
-    empty.textContent = "No catalog loaded.";
+    empty.textContent = t("catalog.empty");
     catalogList.appendChild(empty);
     return;
   }
@@ -735,9 +797,9 @@ function renderCatalogList() {
     const meta = document.createElement("div");
     meta.className = "catalog-item-meta";
     const metaParts = [
-      entry.version ? `Version ${entry.version}` : undefined,
+      entry.version ? t("catalog.meta.version", { value: entry.version }) : undefined,
       fmtBytes(entry.size_bytes),
-      `Hash ${entry.content_sha256}`,
+      t("catalog.meta.hash", { value: entry.content_sha256 }),
     ].filter((part): part is string => part !== undefined);
     meta.textContent = metaParts.join(" | ");
 
@@ -745,16 +807,16 @@ function renderCatalogList() {
     source.className = "catalog-item-subtitle";
     if (loadedCatalogUrl) {
       const urls = deriveBundleAssetUrls(loadedCatalogUrl, entry);
-      source.textContent = `Bundle source: ${urls.base_url}`;
+      source.textContent = t("catalog.meta.bundleSource", { value: urls.base_url });
       const files = document.createElement("div");
       files.className = "catalog-item-subtitle";
       files.textContent =
-        `Manifest: ${urls.manifest_url}\n` +
-        `Records: ${urls.records_url}\n` +
-        `Index: ${urls.search_index_url}`;
+        `${t("catalog.meta.manifest", { value: urls.manifest_url })}\n` +
+        `${t("catalog.meta.recordsFile", { value: urls.records_url })}\n` +
+        t("catalog.meta.indexFile", { value: urls.search_index_url });
       item.append(header, meta, source, files);
     } else {
-      source.textContent = `Source base: ${entry.url_base}`;
+      source.textContent = t("catalog.meta.sourceBase", { value: entry.url_base });
       item.append(header, meta, source);
     }
 
@@ -770,7 +832,7 @@ function renderCatalogList() {
     const actionBtn = document.createElement("button");
     actionBtn.className = "btn";
     actionBtn.textContent = getCatalogActionLabel(entry);
-    actionBtn.disabled = busy || !loadedCatalogUrl || actionBtn.textContent === "Active";
+    actionBtn.disabled = busy || !loadedCatalogUrl || actionBtn.textContent === t("catalog.badge.active");
     actionBtn.addEventListener("click", () => {
       const { activateOnCommit } = getCatalogEntryRuntimeState(entry);
       void withSingleWriterLock(`install catalog bundle ${entry.bundle_id}`, async () => {
@@ -790,7 +852,7 @@ function renderBundleSelectOptions(activeBundleId: string | undefined) {
   if (installedBundles.length === 0) {
     const option = document.createElement("option");
     option.value = "";
-    option.textContent = "No dictionaries installed";
+    option.textContent = t("manage.noneInstalled");
     bundleSelect.appendChild(option);
     bundleSelect.disabled = true;
     return;
@@ -829,7 +891,9 @@ async function refreshDbStatus() {
         firstRun.style.display = "none";
         retryFeaturedInstallBtn.style.display = "none";
         featuredInstallStatus.textContent = "";
-        activeDictionarySummary.textContent = `Using: ${getInstalledBundleName(active)} — ready to search`;
+        activeDictionarySummary.textContent = t("activeDictionary.usingReady", {
+          name: getInstalledBundleName(active),
+        });
         const statusText =
           `Active: ${getInstalledBundleName(active)}\n` +
           `Bundle ID: ${active.bundle_id}\n` +
@@ -839,28 +903,23 @@ async function refreshDbStatus() {
           `Imported: ${active.imported_at_iso}\n` +
           `Records: ${active.records_count ?? "n/a"} | Index entries: ${active.index_entries_count ?? "n/a"}\n` +
           `Approx payload: ${fmtBytes(active.storage_bytes)}\n`;
-        dictStatus.textContent = "Dictionary ready for offline search.";
+        dictStatus.textContent = t("status.dictionaryReady");
         dbOut.textContent = statusText;
       } else {
         hasActiveBundle = false;
-        activeDictionarySummary.textContent = "No active dictionary";
+        activeDictionarySummary.textContent = t("activeDictionary.none");
         const hasRecordsData = await storeHasData(db, STORE_RECORDS);
         const hasIndexData = await storeHasData(db, STORE_SEARCH_INDEX);
         if (bundles.length > 0) {
           firstRun.style.display = "none";
           importProgress.style.display = "none";
-          const warnText =
-            `Installed bundles present, but no active bundle is selected.\n` +
-            `Choose a dictionary from the selector or installed-bundles list to enable search.\n`;
+          const warnText = t("status.noActiveSelection");
           dictStatus.textContent = warnText;
           dbOut.textContent = warnText;
         } else if (hasRecordsData || hasIndexData) {
           firstRun.style.display = "none";
           importProgress.style.display = "none";
-          const warnText =
-            `Warning: partial data from a failed or interrupted import.\n` +
-            `No active bundle. Search is disabled.\n` +
-            `Delete the database and re-import.\n`;
+          const warnText = t("status.partialDataWarning");
           dictStatus.textContent = warnText;
           dbOut.textContent = warnText;
         } else {
@@ -868,17 +927,15 @@ async function refreshDbStatus() {
           importProgress.style.display = "none";
           if (!navigator.onLine) {
             featuredInstallStatus.textContent =
-              "No dictionary installed and you appear to be offline.\n" +
-              "Connect and retry featured install, or use Manage dictionaries → Advanced setup.";
+              t("firstRun.offlineNoDictionary");
             retryFeaturedInstallBtn.style.display = "";
           } else {
             featuredInstallStatus.textContent =
-              "Install the deployment-configured featured dictionary to start searching.\n" +
-              "Advanced setup is available for custom catalogs and manual import.";
+              t("firstRun.onlinePrompt");
             retryFeaturedInstallBtn.style.display = "none";
           }
-          dictStatus.textContent = "No active dictionary installed yet.";
-          dbOut.textContent = "No active bundle.\n";
+          dictStatus.textContent = t("status.noActiveDictionaryInstalled");
+          dbOut.textContent = t("status.noActiveBundle");
         }
       }
     } finally {
@@ -893,7 +950,7 @@ async function refreshDbStatus() {
     renderInstalledBundleManager();
     firstRun.style.display = "none";
     importProgress.style.display = "none";
-    dictStatus.textContent = `Database error: ${String(e)}\n`;
+    dictStatus.textContent = t("status.dbError", { error: String(e) });
     dbOut.textContent = dictStatus.textContent;
   }
   renderCatalogList();
@@ -990,18 +1047,18 @@ async function quickImportBundle(fileList: FileList) {
   if (missing.length > 0) {
     importProgress.style.display = "";
     importProgress.textContent =
-      `Missing required files: ${missing.join(", ")}\n\n` +
-      `Select all 3 bundle files:\n  bundle.manifest.json\n  records.jsonl\n  search_index.jsonl`;
+      t("import.missingRequiredFiles", { files: missing.join(", ") }) +
+      t("import.selectAllThreeFiles");
     return;
   }
 
   importProgress.style.display = "";
-  importProgress.textContent = "Validating manifest...\n";
+  importProgress.textContent = t("import.validatingManifest");
 
   const txt = await manifestFileObj!.text();
   const parsed = parseAndValidateManifestJson(txt);
   if (!parsed.ok || !parsed.manifest) {
-    importProgress.textContent = "Manifest validation failed:\n";
+    importProgress.textContent = t("import.manifestValidationFailed");
     for (const err of parsed.errors) importProgress.textContent += `  ${err}\n`;
     return;
   }
@@ -1013,7 +1070,7 @@ async function quickImportBundle(fileList: FileList) {
     search_index: searchIndexFileObj!,
   });
   if (fileCheck.errors.length > 0) {
-    importProgress.textContent = `File validation failed for ${mfst.bundle_id}:\n`;
+    importProgress.textContent = t("import.fileValidationFailedFor", { bundleId: mfst.bundle_id });
     for (const err of fileCheck.errors) importProgress.textContent += `  ${err}\n`;
     return;
   }
@@ -1027,16 +1084,20 @@ async function quickImportBundle(fileList: FileList) {
       if (installed.expected_content_sha256 === mfst.content_sha256) {
         await setActiveBundleId(existingDb, mfst.bundle_id);
         existingDb.close();
-        importProgress.textContent = `Bundle already installed. Marked active: ${mfst.bundle_id}\n`;
+        importProgress.textContent = t("import.bundleAlreadyInstalledMarkedActive", {
+          bundleId: mfst.bundle_id,
+        });
         await refreshDbStatus();
         return;
       }
       activateOnCommit = activeBundleId === mfst.bundle_id;
       importProgress.textContent =
-        `Updating installed bundle ${mfst.bundle_id}.\n` +
-        `Existing hash: ${installed.expected_content_sha256 ?? "unknown"}\n` +
-        `New hash: ${mfst.content_sha256}\n` +
-        `${activateOnCommit ? "Updated bundle will remain active." : "Current active bundle will remain unchanged."}\n`;
+        t("import.updatingBundle", { bundleId: mfst.bundle_id }) +
+        t("import.existingHash", { hash: installed.expected_content_sha256 ?? "unknown" }) +
+        t("import.newHash", { hash: mfst.content_sha256 }) +
+        (activateOnCommit
+          ? t("import.updatedBundleRemainActive")
+          : t("import.currentActiveRemainUnchanged"));
     }
     existingDb.close();
   } catch {
@@ -1044,7 +1105,7 @@ async function quickImportBundle(fileList: FileList) {
   }
 
   firstRun.style.display = "none";
-  importProgress.textContent = `Installing ${mfst.bundle_id}...\n`;
+  importProgress.textContent = t("import.installingBundle", { bundleId: mfst.bundle_id });
 
   const db = await openSiralexDb();
   try {
@@ -1060,21 +1121,29 @@ async function quickImportBundle(fileList: FileList) {
       },
       undefined,
       {
-        displayName: getBundleDisplayName(mfst.bundle_id, buildLanguageMetaFromManifest(mfst)),
+        displayName: getBundleDisplayName(
+          mfst.bundle_id,
+          buildLanguageMetaFromManifest(mfst),
+          t("language.source"),
+          t("language.target"),
+        ),
         storageBytes: getManifestPayloadBytes(mfst),
       },
       activateOnCommit,
     );
     importProgress.textContent =
-      `Install complete: ${mfst.bundle_id}\n` +
-      `${result.recordsCount} records, ${result.indexCount} index entries\n` +
-      `${result.elapsedMs.toFixed(0)} ms\n`;
+      t("import.installComplete", {
+        bundleId: mfst.bundle_id,
+        records: result.recordsCount,
+        indexEntries: result.indexCount,
+        elapsed: result.elapsedMs.toFixed(0),
+      });
     if (result.cleanupWarning) {
       importProgress.textContent += `\n${result.cleanupWarning}\n`;
     }
   } catch (e) {
-    importProgress.textContent += `\nImport failed: ${String(e)}\n`;
-    importProgress.textContent += `Partial bundle data removed. Re-import required.\n`;
+    importProgress.textContent += t("import.importFailed", { error: String(e) });
+    importProgress.textContent += t("import.partialRemovedReimport");
   } finally {
     db.close();
   }
@@ -1092,7 +1161,7 @@ async function loadCatalogFromUrl(
 
   catalogLoading = true;
   updateCatalogControls();
-  statusTarget.textContent = `Loading catalog from ${catalogUrl}...\n`;
+  statusTarget.textContent = t("catalog.loading", { url: catalogUrl });
 
   try {
     const result = await fetchBundleCatalog(catalogUrl, {
@@ -1114,23 +1183,22 @@ async function loadCatalogFromUrl(
     if (opts.updateCatalogInput !== false) {
       catalogUrlInput.value = catalogUrl;
     }
-    statusTarget.textContent =
-      `Catalog loaded.\n` +
-      `Source: ${result.responseUrl}\n` +
-      `Bundles: ${result.catalog.bundles.length}\n` +
-      `Fetched at: ${cached.fetched_at_iso}\n` +
-      `Remote policy: https anywhere; http only for same-origin or local hubs (localhost, .local, private IPs).\n` +
-      `Bundle URL contract: url_base + bundle.manifest.json / records.jsonl / search_index.jsonl\n`;
+    statusTarget.textContent = t("catalog.loaded", {
+      source: result.responseUrl,
+      count: result.catalog.bundles.length,
+      fetchedAt: cached.fetched_at_iso,
+    });
     for (const warning of result.warnings) {
-      statusTarget.textContent += `WARN: ${warning}\n`;
+      statusTarget.textContent += t("catalog.warnPrefix", { warning });
     }
     return result.catalog.bundles;
   } catch (e) {
-    statusTarget.textContent = `Catalog load failed: ${String(e)}\n`;
+    statusTarget.textContent = t("catalog.loadFailed", { error: String(e) });
     if (loadedCatalogBundles.length > 0 && loadedCatalogUrl && loadedCatalogFetchedAtIso) {
-      statusTarget.textContent +=
-        `Showing cached catalog from ${loadedCatalogUrl}\n` +
-        `Fetched at: ${loadedCatalogFetchedAtIso}\n`;
+      statusTarget.textContent += t("catalog.showingCachedFrom", {
+        url: loadedCatalogUrl,
+        fetchedAt: loadedCatalogFetchedAtIso,
+      });
     }
     throw e;
   } finally {
@@ -1152,23 +1220,21 @@ async function installFeaturedDictionary() {
   featuredInstallInProgress = true;
   updateFeaturedInstallControls();
   retryFeaturedInstallBtn.style.display = "none";
-  featuredInstallStatus.textContent = "Install started.\n";
+  featuredInstallStatus.textContent = t("featured.installStarted");
 
   try {
     if (!navigator.onLine && installedBundles.length === 0) {
-      featuredInstallStatus.textContent =
-        "No dictionary installed and no network connection detected.\n" +
-        "Connect and retry, or use Manage dictionaries → Advanced setup for manual import/custom catalog recovery.";
+      featuredInstallStatus.textContent = t("firstRun.offlineNoDictionary");
       retryFeaturedInstallBtn.style.display = "";
       return;
     }
 
-    featuredInstallStatus.textContent += "Downloading/preparing dictionary...\n";
+    featuredInstallStatus.textContent += t("featured.downloading");
     await withSingleWriterLock("install featured dictionary", async () => {
       await loadCatalogFromUrl(FEATURED_CATALOG_URL, featuredInstallStatus, { updateCatalogInput: false });
       const entry = getFeaturedCatalogEntry();
       if (!entry) {
-        throw new Error("No featured dictionary entry found in catalog");
+        throw new Error(t("featured.noEntryFound"));
       }
       const installResult = await installCatalogEntry(entry, true, featuredInstallStatus);
       if (!installResult.ok) {
@@ -1177,14 +1243,10 @@ async function installFeaturedDictionary() {
     });
 
     featuredInstallStatus.textContent =
-      "Installed and ready to search.\n" +
-      "Manage dictionaries and advanced setup remain available from Manage dictionaries.";
-    dictStatus.textContent = "Dictionary installed and ready for offline search.";
+      t("featured.installed");
+    dictStatus.textContent = t("status.dictionaryReady");
   } catch (e) {
-    featuredInstallStatus.textContent =
-      "Install failed.\n" +
-      `${String(e)}\n` +
-      "Retry install or open Manage dictionaries → Advanced setup for recovery.";
+    featuredInstallStatus.textContent = t("featured.installFailed", { error: String(e) });
     retryFeaturedInstallBtn.style.display = "";
   } finally {
     featuredInstallInProgress = false;
@@ -1198,13 +1260,12 @@ async function restoreCachedCatalogFromDb() {
     const cached = await getCachedBundleCatalog(db);
     if (!cached) return;
     applyCachedCatalog(cached, "cache");
-    catalogStatus.textContent =
-      `Cached catalog restored.\n` +
-      `Source: ${cached.response_url}\n` +
-      `Fetched at: ${cached.fetched_at_iso}\n` +
-      `Load catalog to refresh from the network.\n`;
+    catalogStatus.textContent = t("catalog.cachedRestored", {
+      source: cached.response_url,
+      fetchedAt: cached.fetched_at_iso,
+    });
     for (const warning of cached.warnings) {
-      catalogStatus.textContent += `WARN: ${warning}\n`;
+      catalogStatus.textContent += t("catalog.warnPrefix", { warning });
     }
   } finally {
     db.close();
@@ -1218,7 +1279,7 @@ async function installCatalogEntry(
 ): Promise<{ ok: boolean; message: string }> {
   if (!loadedCatalogUrl) {
     progressTarget.style.display = "";
-    progressTarget.textContent = "No catalog source URL is available for this entry.\n";
+    progressTarget.textContent = t("catalog.missingSourceUrl");
     return { ok: false, message: "missing catalog source URL" };
   }
 
@@ -1228,7 +1289,9 @@ async function installCatalogEntry(
     if (installed?.expected_content_sha256 === entry.content_sha256) {
       await setActiveBundleId(existingDb, entry.bundle_id);
       progressTarget.style.display = "";
-      progressTarget.textContent = `Bundle already installed. Marked active: ${entry.bundle_id}\n`;
+      progressTarget.textContent = t("import.bundleAlreadyInstalledMarkedActive", {
+        bundleId: entry.bundle_id,
+      });
       return { ok: true, message: "already installed; activated" };
     }
   } finally {
@@ -1240,7 +1303,7 @@ async function installCatalogEntry(
   remoteInstallBundleId = entry.bundle_id;
   updateInstallControls();
   progressTarget.style.display = "";
-  progressTarget.textContent = `Preparing remote install for ${entry.bundle_id}...\n`;
+  progressTarget.textContent = t("catalog.prepareRemoteInstall", { bundleId: entry.bundle_id });
 
   const db = await openSiralexDb();
   try {
@@ -1250,6 +1313,19 @@ async function installCatalogEntry(
       onUpdate: (message) => {
         progressTarget.textContent = message;
       },
+      progressCopy: {
+        installingPrefix: t("progress.installingPrefix"),
+        stageLabel: t("progress.stageLabel"),
+        stageFetchingManifest: t("progress.stage.fetchManifest"),
+        stageFetchingRecords: t("progress.stage.fetchRecords"),
+        stageFetchingSearchIndex: t("progress.stage.fetchSearchIndex"),
+        stageStagingPayloads: t("progress.stage.stagingPayloads"),
+        bytesReadLabel: t("progress.bytesReadLabel"),
+        linesSeenLabel: t("progress.linesSeenLabel"),
+        recordsWrittenLabel: t("progress.recordsWrittenLabel"),
+        entriesWrittenLabel: t("progress.entriesWrittenLabel"),
+        batchesCommittedLabel: t("progress.batchesCommittedLabel"),
+      },
       storageEstimate:
         typeof navigator !== "undefined" && navigator.storage?.estimate
           ? async () => await navigator.storage.estimate()
@@ -1258,13 +1334,18 @@ async function installCatalogEntry(
 
     if (result.skippedBecauseCurrent) {
       await setActiveBundleId(db, manifest.bundle_id);
-      progressTarget.textContent = `Bundle already installed. Marked active: ${manifest.bundle_id}\n`;
+      progressTarget.textContent = t("import.bundleAlreadyInstalledMarkedActive", {
+        bundleId: manifest.bundle_id,
+      });
       return { ok: true, message: "already installed; activated" };
     } else {
       progressTarget.textContent =
-        `Remote install complete: ${manifest.bundle_id}\n` +
-        `${result.recordsCount} records, ${result.indexCount} index entries\n` +
-        `${result.elapsedMs.toFixed(0)} ms\n`;
+        t("catalog.remoteInstallComplete", {
+          bundleId: manifest.bundle_id,
+          records: result.recordsCount,
+          indexEntries: result.indexCount,
+          elapsed: result.elapsedMs.toFixed(0),
+        });
       if (result.cleanupWarning) {
         progressTarget.textContent += `\n${result.cleanupWarning}\n`;
       }
@@ -1273,7 +1354,7 @@ async function installCatalogEntry(
   } catch (e) {
     console.error("REMOTE INSTALL FAILED", e);
     progressTarget.textContent =
-      `Install FAILED\n` +
+      t("catalog.installFailedHeader") +
       `${formatErrorDetails(e)}\n`;
     return { ok: false, message: String(e) };
   } finally {
@@ -1332,7 +1413,12 @@ async function validateManifestAndFiles() {
   lastValidatedManifest = mfst;
   manifestOut.textContent += `Manifest OK\n`;
   manifestOut.textContent += `bundle_id: ${mfst.bundle_id}\n`;
-  manifestOut.textContent += `dictionary: ${getBundleDisplayName(mfst.bundle_id, buildLanguageMetaFromManifest(mfst))}\n`;
+  manifestOut.textContent += `dictionary: ${getBundleDisplayName(
+    mfst.bundle_id,
+    buildLanguageMetaFromManifest(mfst),
+    t("language.source"),
+    t("language.target"),
+  )}\n`;
   manifestOut.textContent += `normalization: ${mfst.rule_versions.normalization}\n`;
   manifestOut.textContent += `schema: ${mfst.record_schema_id}@${mfst.record_schema_version}\n`;
   manifestOut.textContent += `mode: ${mfst.update_mode} / ${mfst.reconciliation_action}\n`;
@@ -1396,7 +1482,12 @@ importBundleBtn.addEventListener("click", () => {
         },
         undefined,
         {
-          displayName: getBundleDisplayName(mfst.bundle_id, buildLanguageMetaFromManifest(mfst)),
+          displayName: getBundleDisplayName(
+            mfst.bundle_id,
+            buildLanguageMetaFromManifest(mfst),
+            t("language.source"),
+            t("language.target"),
+          ),
           storageBytes: getManifestPayloadBytes(mfst),
         },
         activateOnCommit,
@@ -1429,12 +1520,12 @@ clearDbBtn.addEventListener("click", () => {
     manifestOut.textContent = "";
     lastValidatedManifest = undefined;
     importProgress.style.display = "";
-    importProgress.textContent = "Deleting database...\n";
+    importProgress.textContent = t("db.deleting");
     try {
       await deleteSiralexDb();
-      importProgress.textContent = "Database deleted.\n";
+      importProgress.textContent = t("db.deleted");
     } catch (e) {
-      importProgress.textContent += `Delete failed: ${String(e)}\n`;
+      importProgress.textContent += t("db.deleteFailed", { error: String(e) });
     }
     await refreshDbStatus();
   });
@@ -1531,7 +1622,7 @@ function renderRecentQueryLogs(rows: QueryLogEventV1[]): DocumentFragment {
   if (rows.length === 0) {
     const empty = document.createElement("p");
     empty.className = "mono";
-    empty.textContent = "No logs yet.";
+    empty.textContent = t("logging.noLogsYet");
     frag.appendChild(empty);
     return frag;
   }
@@ -1596,13 +1687,13 @@ async function updateRecentQueryLogsView() {
     recentQueryLogsTableHost.replaceChildren();
     const err = document.createElement("p");
     err.className = "mono";
-    err.textContent = `Recent logs error: ${String(e)}`;
+    err.textContent = t("logging.recentLogsError", { error: String(e) });
     recentQueryLogsTableHost.appendChild(err);
   }
 }
 
 async function refreshQueryLoggingCount() {
-  const result = await getQueryLogCountFromDb();
+  const result = await getQueryLogCountFromDb({ translate: t });
   queryLoggingCount.textContent = result.message;
   if (!result.ok) {
     queryLogMessage.textContent = result.message;
@@ -1611,8 +1702,8 @@ async function refreshQueryLoggingCount() {
 
 function updateQueryLoggingToggleState() {
   const enabled = getQueryLoggingEnabled();
-  queryLoggingStatus.textContent = enabled ? "On" : "Off";
-  queryLoggingToggleBtn.textContent = enabled ? "Turn Off" : "Turn On";
+  queryLoggingStatus.textContent = enabled ? t("logging.on") : t("logging.off");
+  queryLoggingToggleBtn.textContent = enabled ? t("logging.turnOff") : t("logging.turnOn");
   queryLoggingToggleBtn.setAttribute("aria-pressed", enabled ? "true" : "false");
 }
 
@@ -1624,10 +1715,21 @@ async function renderQueryLoggingToggle() {
 }
 
 function updateLangToggle() {
-  const directionText = getSearchDirectionText(searchDirection, currentActiveBundle?.language_meta);
+  const directionText = getSearchDirectionText(
+    searchDirection,
+    currentActiveBundle?.language_meta,
+    t("language.source"),
+    t("language.target"),
+  );
   langToggle.textContent = directionText;
-  searchLabel.textContent = `Query (${directionText})`;
-  searchInput.placeholder = getSearchPlaceholder(searchDirection, currentActiveBundle?.language_meta);
+  searchLabel.textContent = t("search.queryLabel", { direction: directionText });
+  searchInput.placeholder = getSearchPlaceholder(
+    searchDirection,
+    currentActiveBundle?.language_meta,
+    t("language.source"),
+    t("language.target"),
+    (label) => t("search.placeholder", { language: label }),
+  );
 }
 
 queryLoggingToggleBtn.addEventListener("click", () => {
@@ -1643,7 +1745,7 @@ queryLoggingToggleBtn.addEventListener("click", () => {
 
 queryLogExportBtn.addEventListener("click", () => {
   void (async () => {
-    const result = await exportQueryLogsFromUi();
+    const result = await exportQueryLogsFromUi({ translate: t });
     queryLogMessage.textContent = result.message;
     await refreshQueryLoggingCount();
   })();
@@ -1651,7 +1753,7 @@ queryLogExportBtn.addEventListener("click", () => {
 
 queryLogClearBtn.addEventListener("click", () => {
   void (async () => {
-    const result = await clearQueryLogsFromUi();
+    const result = await clearQueryLogsFromUi({ translate: t });
     queryLogMessage.textContent = result.message;
     await refreshQueryLoggingCount();
     await updateRecentQueryLogsView();
@@ -1763,18 +1865,22 @@ function showEntryDetail(record: EnrichedRecord) {
   const detail = renderEntryDetail(record, {
     onBack: () => showResultsList(),
     onSearch: (query) => triggerSearch(query),
-    targetEntriesLabel: getTargetEntriesLabel(currentActiveBundle?.language_meta),
+    targetEntriesLabel: getTargetEntriesLabel(
+      currentActiveBundle?.language_meta,
+      t("language.target"),
+      (label) => t("entry.targetEntries", { label }),
+    ),
   });
   searchResults.appendChild(detail);
 }
 
 async function runSearch(query: string) {
   if (busy) {
-    searchMeta.textContent = "Search temporarily unavailable during install/update.";
+    searchMeta.textContent = t("search.disabledBusy");
     return;
   }
   if (!hasActiveBundle) {
-    searchMeta.textContent = "Search disabled: no active bundle.";
+    searchMeta.textContent = t("search.disabledNoActiveBundle");
     return;
   }
   const seq = ++searchSeq;
@@ -1784,7 +1890,7 @@ async function runSearch(query: string) {
     db = await openSiralexDb();
     const activeBundleMeta = await getActiveBundleMeta(db);
     if (!activeBundleMeta) {
-      searchMeta.textContent = "Search disabled: no active bundle.";
+      searchMeta.textContent = t("search.disabledNoActiveBundle");
       searchResults.innerHTML = "";
       lastSearchRecords = [];
       return;
@@ -1802,8 +1908,10 @@ async function runSearch(query: string) {
 
     if (result.ir_ids.length === 0) {
       const elapsedMs = performance.now() - t0;
-      searchMeta.textContent =
-        `Query: "${query}" — No matches (all 4 levels checked). ${elapsedMs.toFixed(1)} ms`;
+      searchMeta.textContent = t("search.noMatch", {
+        query,
+        elapsed: elapsedMs.toFixed(1),
+      });
       searchResults.innerHTML = "";
       lastSearchRecords = [];
       scheduleSettledQueryLog({
@@ -1821,9 +1929,13 @@ async function runSearch(query: string) {
     if (seq !== searchSeq) return;
     const elapsedMs = performance.now() - t0;
 
-    searchMeta.textContent =
-      `Query: "${query}" — ${records.length} result(s) at level: ${result.matched_key_type} ` +
-      `[key: "${result.matched_key}"] ${elapsedMs.toFixed(1)} ms`;
+    searchMeta.textContent = t("search.resultMeta", {
+      query,
+      count: records.length,
+      level: String(result.matched_key_type),
+      key: String(result.matched_key),
+      elapsed: elapsedMs.toFixed(1),
+    });
 
     lastSearchRecords = records;
     showResultsList();
@@ -1837,7 +1949,7 @@ async function runSearch(query: string) {
     });
   } catch (e) {
     if (seq !== searchSeq) return;
-    searchMeta.textContent = `Search error: ${String(e)}`;
+    searchMeta.textContent = t("search.error", { error: String(e) });
     searchResults.innerHTML = "";
     lastSearchRecords = [];
   } finally {

--- a/web/src/query_logging/query_log_controls.ts
+++ b/web/src/query_logging/query_log_controls.ts
@@ -17,10 +17,67 @@ type QueryLogControlsDeps = {
   now?: () => Date;
   openDb?: typeof openSiralexDb;
   revokeObjectUrl?: (url: string) => void;
+  translate?: (
+    key:
+      | "queryLogs.clearConfirm"
+      | "queryLogs.noLogsToExport"
+      | "queryLogs.clearCancelled"
+      | "queryLogs.cleared"
+      | "queryLogs.count.one"
+      | "queryLogs.count.many"
+      | "queryLogs.countError"
+      | "queryLogs.exported.one"
+      | "queryLogs.exported.many"
+      | "queryLogs.exportFailed"
+      | "queryLogs.clearFailed",
+    vars?: Record<string, string | number>,
+  ) => string;
 };
 
-const CLEAR_CONFIRMATION_MESSAGE = "Clear all local query logs from this device?";
-const NO_LOGS_TO_EXPORT_MESSAGE = "No logs to export.";
+function t(
+  deps: QueryLogControlsDeps,
+  key:
+    | "queryLogs.clearConfirm"
+    | "queryLogs.noLogsToExport"
+    | "queryLogs.clearCancelled"
+    | "queryLogs.cleared"
+    | "queryLogs.count.one"
+    | "queryLogs.count.many"
+    | "queryLogs.countError"
+    | "queryLogs.exported.one"
+    | "queryLogs.exported.many"
+    | "queryLogs.exportFailed"
+    | "queryLogs.clearFailed",
+  vars?: Record<string, string | number>,
+): string {
+  if (deps.translate) {
+    return deps.translate(key, vars);
+  }
+  switch (key) {
+    case "queryLogs.clearConfirm":
+      return "Clear all local query logs from this device?";
+    case "queryLogs.noLogsToExport":
+      return "No logs to export.";
+    case "queryLogs.clearCancelled":
+      return "Clear cancelled.";
+    case "queryLogs.cleared":
+      return "Cleared query logs.";
+    case "queryLogs.count.one":
+      return "1 log";
+    case "queryLogs.count.many":
+      return `${vars?.count ?? 0} logs`;
+    case "queryLogs.countError":
+      return `Log count error: ${String(vars?.error ?? "")}`;
+    case "queryLogs.exported.one":
+      return "Exported 1 log.";
+    case "queryLogs.exported.many":
+      return `Exported ${vars?.count ?? 0} logs.`;
+    case "queryLogs.exportFailed":
+      return `Export failed: ${String(vars?.error ?? "")}`;
+    case "queryLogs.clearFailed":
+      return `Clear failed: ${String(vars?.error ?? "")}`;
+  }
+}
 
 function pad2(n: number): string {
   return String(n).padStart(2, "0");
@@ -47,13 +104,13 @@ export async function getQueryLogCountFromDb(
     const count = await countLogsFn(db);
     return {
       count,
-      message: count === 1 ? "1 log" : `${count} logs`,
+      message: count === 1 ? t(deps, "queryLogs.count.one") : t(deps, "queryLogs.count.many", { count }),
       ok: true,
     };
   } catch (error) {
     return {
       count: 0,
-      message: `Log count error: ${String(error)}`,
+      message: t(deps, "queryLogs.countError", { error: String(error) }),
       ok: false,
     };
   } finally {
@@ -76,7 +133,7 @@ export async function exportQueryLogsFromUi(
     if (count === 0) {
       return {
         count: 0,
-        message: NO_LOGS_TO_EXPORT_MESSAGE,
+        message: t(deps, "queryLogs.noLogsToExport"),
         ok: true,
       };
     }
@@ -98,13 +155,16 @@ export async function exportQueryLogsFromUi(
 
     return {
       count,
-      message: `Exported ${count === 1 ? "1 log" : `${count} logs`}.`,
+      message:
+        count === 1
+          ? t(deps, "queryLogs.exported.one")
+          : t(deps, "queryLogs.exported.many", { count }),
       ok: true,
     };
   } catch (error) {
     return {
       count: 0,
-      message: `Export failed: ${String(error)}`,
+      message: t(deps, "queryLogs.exportFailed", { error: String(error) }),
       ok: false,
     };
   } finally {
@@ -116,10 +176,10 @@ export async function clearQueryLogsFromUi(
   deps: QueryLogControlsDeps = {},
 ): Promise<QueryLogUiResult> {
   const confirmFn = deps.confirmFn ?? ((message: string) => window.confirm(message));
-  if (!confirmFn(CLEAR_CONFIRMATION_MESSAGE)) {
+  if (!confirmFn(t(deps, "queryLogs.clearConfirm"))) {
     return {
       count: -1,
-      message: "Clear cancelled.",
+      message: t(deps, "queryLogs.clearCancelled"),
       ok: true,
     };
   }
@@ -133,13 +193,13 @@ export async function clearQueryLogsFromUi(
     const count = await countQueryLogs(db);
     return {
       count,
-      message: "Cleared query logs.",
+      message: t(deps, "queryLogs.cleared"),
       ok: true,
     };
   } catch (error) {
     return {
       count: 0,
-      message: `Clear failed: ${String(error)}`,
+      message: t(deps, "queryLogs.clearFailed", { error: String(error) }),
       ok: false,
     };
   } finally {

--- a/web/src/render/render_entry.ts
+++ b/web/src/render/render_entry.ts
@@ -17,6 +17,7 @@ import type {
   SubEntry,
 } from "../types/records";
 import { isLexiconDisplay, isIndexMappingDisplay } from "../types/records";
+import { t } from "../i18n";
 
 function el(tag: string, cls?: string, text?: string): HTMLElement {
   const e = document.createElement(tag);
@@ -75,10 +76,10 @@ function renderSense(sense: SenseRaw, index: number): HTMLElement {
   wrap.appendChild(header);
 
   if (sense.usage_note) {
-    wrap.appendChild(el("div", "sense-usage", `Usage: ${sense.usage_note}`));
+    wrap.appendChild(el("div", "sense-usage", t("entry.usage", { value: sense.usage_note })));
   }
   if (sense.synonyms_raw && sense.synonyms_raw.length > 0) {
-    wrap.appendChild(el("div", "sense-synonyms", `Syn: ${sense.synonyms_raw.join(", ")}`));
+    wrap.appendChild(el("div", "sense-synonyms", t("entry.synShort", { value: sense.synonyms_raw.join(", ") })));
   }
   if (sense.examples && sense.examples.length > 0) {
     const exWrap = el("div", "sense-examples");
@@ -107,16 +108,16 @@ function renderLexiconEntry(record: EnrichedRecord, d: LexiconDisplayFields): HT
   wrap.appendChild(header);
 
   if (d.variants_raw && d.variants_raw.length > 0) {
-    wrap.appendChild(el("div", "entry-variants", `Variants: ${d.variants_raw.join(", ")}`));
+    wrap.appendChild(el("div", "entry-variants", t("entry.variants", { value: d.variants_raw.join(", ") })));
   }
   if (d.synonyms_raw && d.synonyms_raw.length > 0) {
-    wrap.appendChild(el("div", "entry-synonyms", `Synonyms: ${d.synonyms_raw.join(", ")}`));
+    wrap.appendChild(el("div", "entry-synonyms", t("entry.synonyms", { value: d.synonyms_raw.join(", ") })));
   }
   if (d.etymology_raw) {
-    wrap.appendChild(el("div", "entry-etymology", `Etymology: ${d.etymology_raw}`));
+    wrap.appendChild(el("div", "entry-etymology", t("entry.etymology", { value: d.etymology_raw })));
   }
   if (d.literal_meaning_raw) {
-    wrap.appendChild(el("div", "entry-literal", `Literal: ${d.literal_meaning_raw}`));
+    wrap.appendChild(el("div", "entry-literal", t("entry.literal", { value: d.literal_meaning_raw })));
   }
 
   if (d.senses && d.senses.length > 0) {
@@ -126,11 +127,11 @@ function renderLexiconEntry(record: EnrichedRecord, d: LexiconDisplayFields): HT
   }
 
   const meta = el("div", "entry-meta");
-  meta.appendChild(el("span", "meta-item", `ir_id: ${record.ir_id}`));
-  meta.appendChild(el("span", "meta-item", `source: ${record.source_id}`));
-  meta.appendChild(el("span", "meta-item", `norm: ${record.norm_version}`));
+  meta.appendChild(el("span", "meta-item", t("entry.meta.irId", { value: record.ir_id })));
+  meta.appendChild(el("span", "meta-item", t("entry.meta.source", { value: record.source_id })));
+  meta.appendChild(el("span", "meta-item", t("entry.meta.norm", { value: record.norm_version })));
   if (d.corpus_count != null) {
-    meta.appendChild(el("span", "meta-item", `corpus: ${d.corpus_count}`));
+    meta.appendChild(el("span", "meta-item", t("entry.meta.corpus", { value: d.corpus_count })));
   }
   wrap.appendChild(meta);
 
@@ -173,9 +174,9 @@ function renderIndexMapping(
   }
 
   const meta = el("div", "entry-meta");
-  meta.appendChild(el("span", "meta-item", `ir_id: ${record.ir_id}`));
-  meta.appendChild(el("span", "meta-item", `source: ${record.source_id}`));
-  meta.appendChild(el("span", "meta-item", `norm: ${record.norm_version}`));
+  meta.appendChild(el("span", "meta-item", t("entry.meta.irId", { value: record.ir_id })));
+  meta.appendChild(el("span", "meta-item", t("entry.meta.source", { value: record.source_id })));
+  meta.appendChild(el("span", "meta-item", t("entry.meta.norm", { value: record.norm_version })));
   wrap.appendChild(meta);
 
   return wrap;
@@ -201,7 +202,7 @@ export function renderEntryDetail(
   const backBtn = document.createElement("button");
   backBtn.className = "btn entry-back";
   backBtn.type = "button";
-  backBtn.textContent = "\u2190 Back to results";
+  backBtn.textContent = t("entry.back");
   backBtn.addEventListener("click", callbacks.onBack);
   container.appendChild(backBtn);
 
@@ -212,12 +213,12 @@ export function renderEntryDetail(
       renderIndexMapping(
         record,
         record.display,
-        callbacks.targetEntriesLabel ?? "Target entries:",
+        callbacks.targetEntriesLabel ?? t("entry.targetEntriesDefault"),
         callbacks.onSearch,
       ),
     );
   } else {
-    container.appendChild(el("div", "entry-error", `No display data for ir_id: ${record.ir_id}`));
+    container.appendChild(el("div", "entry-error", t("entry.noDisplay", { id: record.ir_id })));
   }
 
   return container;

--- a/web/src/render/render_results.ts
+++ b/web/src/render/render_results.ts
@@ -11,10 +11,9 @@ import type {
   IndexMappingDisplayFields,
 } from "../types/records";
 import { isLexiconDisplay, isIndexMappingDisplay } from "../types/records";
+import { t } from "../i18n";
 
 type Summary = { headword: string; pos: string; translation: string; kind: string };
-
-const NO_TRANSLATION = "(no translation available)";
 
 function summarizeLexicon(d: LexiconDisplayFields): Summary {
   const pos = d.pos_hint ?? d.ps_raw ?? "";
@@ -24,8 +23,8 @@ function summarizeLexicon(d: LexiconDisplayFields): Summary {
   return {
     headword: d.headword_latin,
     pos,
-    translation: firstGloss || NO_TRANSLATION,
-    kind: "lexicon",
+    translation: firstGloss || t("render.noTranslation"),
+    kind: t("render.kindLexicon"),
   };
 }
 
@@ -34,8 +33,8 @@ function summarizeIndexMapping(d: IndexMappingDisplayFields): Summary {
   return {
     headword: d.source_term,
     pos: d.source_lang,
-    translation: targetText || NO_TRANSLATION,
-    kind: "index",
+    translation: targetText || t("render.noTranslation"),
+    kind: t("render.kindIndex"),
   };
 }
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -91,6 +91,31 @@ input[type="text"]::placeholder {
   color: var(--muted);
 }
 
+#localeSelect {
+  border: 1px solid color-mix(in oklab, var(--panel) 75%, white 25%);
+  background: color-mix(in oklab, var(--panel) 88%, black 12%);
+  color: var(--text);
+  border-radius: 10px;
+  padding: 8px 10px;
+  font: inherit;
+  font-size: 13px;
+  width: 160px;
+  box-sizing: border-box;
+}
+
+#localeSelect:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--accent) 55%, white 10%);
+  outline-offset: 1px;
+}
+
+.locale-control {
+  min-width: 150px;
+}
+
+.locale-control .label {
+  font-size: 14px;
+}
+
 .btn {
   appearance: none;
   border: 1px solid color-mix(in oklab, var(--panel) 75%, white 25%);


### PR DESCRIPTION
Ship Phase 6D localization by introducing a lightweight EN/FR i18n layer, wiring consumer-facing UI copy through localized keys, and adding a persisted in-app interface language selector with French-first deployment defaults.

## What does this PR change?

- 

## Why?

- 

## Checklist (required)

- [ ] I kept this PR narrowly scoped.
- [ ] If I changed language data / meaning, I explained the impact and any uncertainty.
- [ ] If this touches third-party sources, I preserved attribution and did not add content without permission.
- [ ] If this changes normalization/transliteration behavior, I added examples (inputs → outputs) in the PR description.

## Screenshots / notes (if applicable)

- 

