### PR TITLE
feat(normalization): add norm_v3 for NFC search-key canonicalization

### DIFF
--- a/api/bundle_builder/build_bundle.py
+++ b/api/bundle_builder/build_bundle.py
@@ -205,10 +205,10 @@ def _is_directional_ruleset(normalization_ruleset: str) -> bool:
     Declare search-index direction capability from build ruleset contract.
 
     Current contract:
-    - norm_v2 bundles are directional
+    - norm_v2 and norm_v3 bundles use directional src_*/tgt_* keys
     - older rulesets are treated as legacy
     """
-    return normalization_ruleset == "norm_v2"
+    return normalization_ruleset in ("norm_v2", "norm_v3")
 
 
 def _collect_search_index_key_types(search_index_path: Path) -> set[str]:

--- a/api/bundle_builder/tests/test_bundle_builder.py
+++ b/api/bundle_builder/tests/test_bundle_builder.py
@@ -85,6 +85,43 @@ SAMPLE_NORMALIZED_RECORDS_V2 = [
     },
 ]
 
+SAMPLE_NORMALIZED_RECORDS_V3 = [
+    {
+        "ir_id": "ffff1111eeee2222",
+        "ir_kind": "index_mapping",
+        "source_id": "src_malipense",
+        "norm_version": "norm_v3",
+        "preferred_form": "a) bon travail! (une salutation), b) merci! (pour un travail)",
+        "variant_forms": [
+            "a) bon travail! (une salutation), b) merci! (pour un travail)",
+            "bon travail",
+            "merci",
+        ],
+        "search_keys": {
+            "casefold": [
+                "a) bon travail! (une salutation), b) merci! (pour un travail)",
+                "bon travail",
+                "merci",
+            ],
+            "diacritics_insensitive": [
+                "a) bon travail! (une salutation), b) merci! (pour un travail)",
+                "bon travail",
+                "merci",
+            ],
+            "punct_stripped": [
+                "a bon travail une salutation b merci pour un travail",
+                "bon travail",
+                "merci",
+            ],
+            "nospace": [
+                "a)bontravail!(unesalutation),b)merci!(pouruntravail)",
+                "bontravail",
+                "merci",
+            ],
+        },
+    },
+]
+
 SAMPLE_INDEX_ENTRIES = [
     {
         "key": "test",
@@ -123,6 +160,15 @@ def bundle_inputs_v2(tmp_path):
     normalized = tmp_path / "normalized_v2.jsonl"
     search_index = tmp_path / "search_index_v2.jsonl"
     write_jsonl(normalized, SAMPLE_NORMALIZED_RECORDS_V2)
+    write_jsonl(search_index, SAMPLE_INDEX_ENTRIES_DIRECTIONAL)
+    return normalized, search_index
+
+
+@pytest.fixture
+def bundle_inputs_v3(tmp_path):
+    normalized = tmp_path / "normalized_v3.jsonl"
+    search_index = tmp_path / "search_index_v3.jsonl"
+    write_jsonl(normalized, SAMPLE_NORMALIZED_RECORDS_V3)
     write_jsonl(search_index, SAMPLE_INDEX_ENTRIES_DIRECTIONAL)
     return normalized, search_index
 
@@ -292,8 +338,26 @@ class TestBuildBundle:
 
         assert manifest["rule_versions"]["normalization"] == "norm_v2"
 
+    def test_rule_versions_follow_normalized_records_v3(self, bundle_inputs_v3, tmp_path):
+        normalized, search_index = bundle_inputs_v3
+        output_dir = tmp_path / "bundles"
+
+        result = build_bundle(normalized, search_index, output_dir)
+        manifest = result["manifest"]
+
+        assert manifest["rule_versions"]["normalization"] == "norm_v3"
+
     def test_emits_directional_flag_true_for_norm_v2(self, bundle_inputs_v2, tmp_path):
         normalized, search_index = bundle_inputs_v2
+        output_dir = tmp_path / "bundles"
+
+        result = build_bundle(normalized, search_index, output_dir)
+        manifest = result["manifest"]
+
+        assert manifest["search_index_directional"] is True
+
+    def test_emits_directional_flag_true_for_norm_v3(self, bundle_inputs_v3, tmp_path):
+        normalized, search_index = bundle_inputs_v3
         output_dir = tmp_path / "bundles"
 
         result = build_bundle(normalized, search_index, output_dir)

--- a/api/normalizer/cli.py
+++ b/api/normalizer/cli.py
@@ -12,7 +12,7 @@ from pathlib import Path
 # Add shared to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "shared"))
 
-from normalization.norm_v2 import RULESET_ID
+from normalization.norm_v3 import RULESET_ID
 from .normalize import process_ir_files
 
 logger = logging.getLogger(__name__)

--- a/api/normalizer/normalize.py
+++ b/api/normalizer/normalize.py
@@ -34,7 +34,7 @@ from typing import Any, Iterator
 # Add shared to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "shared"))
 
-from normalization.norm_v2 import (
+from normalization.norm_v3 import (
     RULESET_ID,
     compute_search_keys,
     extract_source_phrases,

--- a/api/normalizer/tests/test_norm_v1_golden_fixtures.py
+++ b/api/normalizer/tests/test_norm_v1_golden_fixtures.py
@@ -262,7 +262,7 @@ class TestNormalizeLexiconEntry:
         }
         result = normalize_lexicon_entry(ir_unit)
         assert result.preferred_form == "dɔ́bɛ̀n"
-        assert result.norm_version == "norm_v2"
+        assert result.norm_version == "norm_v3"
 
     def test_variant_forms_include_preferred(self):
         ir_unit = {

--- a/api/normalizer/tests/test_norm_v2_features.py
+++ b/api/normalizer/tests/test_norm_v2_features.py
@@ -11,9 +11,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "shared"))
 
 from normalization.norm_v2 import (  # noqa: E402
     MAX_SOURCE_PHRASES,
-    RULESET_ID,
     extract_source_phrases,
 )
+from normalization.norm_v3 import RULESET_ID  # noqa: E402 — active pipeline ruleset
 from normalizer.normalize import normalize_index_mapping, normalize_lexicon_entry  # noqa: E402
 
 

--- a/api/normalizer/tests/test_norm_v3.py
+++ b/api/normalizer/tests/test_norm_v3.py
@@ -1,0 +1,112 @@
+"""
+norm_v3: NFC search-key input canonicalization on top of norm_v2 behavior.
+
+norm_v1 and norm_v2 modules must stay behaviorally unchanged; tests here lock
+norm_v3 composition only.
+"""
+
+import sys
+import unicodedata
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "shared"))
+
+from normalization.norm_v2 import (  # noqa: E402
+    compute_search_keys as norm_v2_compute_search_keys,
+    extract_source_phrases,
+)
+from normalization.norm_v3 import RULESET_ID, compute_search_keys as norm_v3_compute_search_keys  # noqa: E402
+from normalizer.normalize import normalize_index_mapping, normalize_lexicon_entry  # noqa: E402
+
+
+def test_ruleset_id_is_norm_v3():
+    assert RULESET_ID == "norm_v3"
+
+
+def test_nfc_canonical_equivalence_kun_maninka():
+    """Composed kùn vs NFD u+combining grave produce identical search keys."""
+    composed = "kùn"
+    decomposed = "ku\u0300n"
+    assert composed != decomposed
+    assert unicodedata.normalize("NFC", decomposed) == composed
+
+    keys_a = norm_v3_compute_search_keys([composed])
+    keys_b = norm_v3_compute_search_keys([decomposed])
+    assert keys_a == keys_b
+    assert "kùn" in keys_a["casefold"]
+
+
+def test_nfc_canonical_equivalence_tete_french():
+    """Composed tête vs NFD e+combining circumflex match under norm_v3."""
+    composed = "tête"
+    decomposed = "te\u0302te"
+    assert unicodedata.normalize("NFC", decomposed) == composed
+
+    keys_a = norm_v3_compute_search_keys([composed])
+    keys_b = norm_v3_compute_search_keys([decomposed])
+    assert keys_a == keys_b
+    assert keys_a["casefold"] == ["tête"]
+
+
+def test_norm_v3_differs_from_norm_v2_on_nfd_latin():
+    """norm_v2 (norm_v1 keys) leaves NFD in casefold; norm_v3 composes first."""
+    decomposed = "ku\u0300n"
+    v2 = norm_v2_compute_search_keys([decomposed])
+    v3 = norm_v3_compute_search_keys([decomposed])
+    assert v2["casefold"] != v3["casefold"]
+    assert v3["casefold"] == ["kùn"]
+
+
+def test_norm_v3_matches_norm_v2_for_nfc_stable_forms():
+    """NFC-stable inputs: identical key material to norm_v2 / norm_v1 path."""
+    forms = ["bonjour", "café", "dɔ́bɛ̀n", "merci le monde"]
+    assert norm_v2_compute_search_keys(forms) == norm_v3_compute_search_keys(forms)
+
+
+def test_norm_v3_normalize_index_mapping_variant_forms_identical_to_extract_v2():
+    """phrase list is still pure norm_v2 extract_source_phrases output."""
+    ir_unit = {
+        "ir_id": "idx-bon-travail",
+        "ir_kind": "index_mapping",
+        "source_id": "src_malipense",
+        "fields_raw": {
+            "source_term": (
+                "a) bon travail! (une salutation à celui qui est en train de travailler), "
+                "b) merci! (pour un travail)"
+            ),
+            "source_lang": "fr",
+        },
+    }
+    result = normalize_index_mapping(ir_unit)
+    assert result.norm_version == RULESET_ID
+    expected_variants = extract_source_phrases(ir_unit["fields_raw"]["source_term"])
+    assert result.variant_forms == expected_variants
+
+
+def test_norm_v3_normalize_lexicon_entry_preserves_raw_variants():
+    """N'Ko append + anchors unchanged; only norm_version and search_keys move."""
+    ir_unit = {
+        "ir_id": "lex-nko",
+        "ir_kind": "lexicon_entry",
+        "source_id": "src_malipense",
+        "record_locator": {"anchor_names": ["dàa"]},
+        "fields_raw": {
+            "headword_latin": "dàa",
+            "headword_nko_provided": "ߘߊ߰",
+        },
+    }
+    result = normalize_lexicon_entry(ir_unit)
+    assert result.norm_version == RULESET_ID
+    assert result.variant_forms == ["dàa", "ߘߊ߰"]
+    assert "ߘߊ߰" in result.search_keys["casefold"]
+
+
+def test_normalize_pipeline_emits_norm_v3():
+    """Active normalizer stamps norm_v3 on emitted records."""
+    ir_unit = {
+        "ir_id": "x1",
+        "ir_kind": "index_mapping",
+        "source_id": "src_malipense",
+        "fields_raw": {"source_term": "test", "source_lang": "fr"},
+    }
+    assert normalize_index_mapping(ir_unit).norm_version == "norm_v3"

--- a/docs/BUILD_BUNDLE.md
+++ b/docs/BUILD_BUNDLE.md
@@ -29,11 +29,13 @@ Input artifact:
 
 - normalized JSONL file
 
-Example path:
+Example path (substitute the ruleset suffix `N` to match your artifact):
 
 ```text
-data/normalized/<dataset>_normalized_norm_vN.jsonl
+data/normalized/malipense_normalized_norm_vN.jsonl
 ```
+
+Use **`norm_v1`** when reproducing the **frozen v1.0 dataset**. Use the **current successor** artifact — for example **`norm_v3`** — when building the latest search/index bundle from the active normalizer output.
 
 ## Step 2: Build the Search Index
 
@@ -41,7 +43,7 @@ Use `siralex-build-index` to generate `search_index.jsonl` from the normalized r
 
 ```bash
 siralex-build-index \
-  --input data/normalized/malipense_normalized_norm_v1.jsonl \
+  --input data/normalized/malipense_normalized_norm_vN.jsonl \
   --output build/search_index.jsonl
 ```
 
@@ -55,7 +57,7 @@ Use `siralex-build-bundle` to assemble the normalized records and search index i
 
 ```bash
 siralex-build-bundle build \
-  --normalized data/normalized/malipense_normalized_norm_v1.jsonl \
+  --normalized data/normalized/malipense_normalized_norm_vN.jsonl \
   --search-index build/search_index.jsonl \
   --output-dir build/bundles \
   --bundle-type full \
@@ -75,12 +77,12 @@ Result:
 - `search_index.jsonl`
 
 The bundle manifest's `rule_versions.normalization` value is derived from the
-normalized records' `norm_version`. This is how new rulesets such as
-`norm_v2` remain explicit in published bundles.
+normalized records' `norm_version`. This is how rulesets such as
+`norm_v2` / `norm_v3` remain explicit in published bundles.
 
 The builder also emits `search_index_directional` as a bundle capability:
 
-- `norm_v2` build path -> `search_index_directional: true`
+- `norm_v2` / `norm_v3` build path -> `search_index_directional: true`
 - legacy build path -> `search_index_directional: false`
 
 The builder validates that `search_index.jsonl` key families match the declared
@@ -144,11 +146,11 @@ Rules:
 mkdir -p build/bundles
 
 siralex-build-index \
-  --input data/normalized/malipense_normalized_norm_v1.jsonl \
+  --input data/normalized/malipense_normalized_norm_vN.jsonl \
   --output build/search_index.jsonl
 
 siralex-build-bundle build \
-  --normalized data/normalized/malipense_normalized_norm_v1.jsonl \
+  --normalized data/normalized/malipense_normalized_norm_vN.jsonl \
   --search-index build/search_index.jsonl \
   --output-dir build/bundles \
   --bundle-type full \

--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -40,10 +40,13 @@ Current shipped successor for new derived artifacts:
 - `norm_v2`: keeps the full original `source_term`, adds deterministic
   source-phrase extraction for `index_mapping`, and includes
   `headword_nko_provided` in `lexicon_entry.variant_forms`
+- `norm_v3`: same as `norm_v2`, plus NFC canonicalization of **search-key input
+  forms** before key generation (fixes NFC/NFD mismatch at lookup without
+  mutating display forms)
 
 `norm_v1` remains the authoritative ruleset for the frozen v1.0 dataset above.
-`norm_v2` is the validated successor for improved search-quality bundle builds;
-it does not retroactively rewrite the frozen `norm_v1` outputs.
+Later rulesets (`norm_v2`, `norm_v3`, …) are additive successors for improved
+bundle builds; they do not retroactively rewrite the frozen `norm_v1` outputs.
 
 ## How to cite
 

--- a/docs/GLOSS_DECOMPOSITION.md
+++ b/docs/GLOSS_DECOMPOSITION.md
@@ -3,6 +3,10 @@
 This document defines the `norm_v2` source-term decomposition contract used for
 `index_mapping.fields_raw.source_term`.
 
+**`norm_v3`** reuses this contract unchanged (implemented by
+`extract_source_phrases` in `shared/normalization/norm_v2.py`, surfaced through
+`norm_v3`); `norm_v3` only adds NFC preprocessing for **search-key inputs**.
+
 The goal is to improve real search quality without replacing or mutating the
 original stored string.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -285,15 +285,16 @@ DoD:
 | 11 | Phase 3.4 — Multi-bundle support | Platform generalization | ✅ Complete |
 | 12 | Phase 3.5 — Bundle selection + distribution | Platform generalization | ✅ Complete |
 | 13 | Phase 5a — `norm_v2` indexing shipped | Search/index quality | ✅ Complete |
-| 14 | Phase 5b — Field Validation + Search Reality Calibration | Validation track | Substantially complete (Android real-device validation deferred pending hardware access) |
-| 15 | Phase 1.5A — Correction record schema/specification | Next formal engineering milestone | ✅ Complete |
-| 16 | Phase 1.5B — Dry-run correction application pipeline | Follows 1.5A approval | ✅ Complete |
-| 17 | HTTPS + Android validation execution | Active validation follow-up | Pending hardware access |
-| 18 | Branch C — Transliteration, morphology, linguistic inference | Only after users + data | Deferred |
-| 19 | Phase 6B — Consumer Search-First UX + Infrastructure Layering | UX/product milestone | ✅ Complete |
-| 20 | Phase 6D1 — Localization Architecture + French-First Interface Pass | Near-term consumer productization milestone | Implemented (pending review) |
+| 14 | `norm_v3` — NFC search-key canonicalization | Search/index correctness | ✅ Code/spec complete; real `norm_v3` bundle regeneration and distribution pending |
+| 15 | Phase 5b — Field Validation + Search Reality Calibration | Validation track | Substantially complete (Android real-device validation deferred pending hardware access) |
+| 16 | Phase 1.5A — Correction record schema/specification | Next formal engineering milestone | ✅ Complete |
+| 17 | Phase 1.5B — Dry-run correction application pipeline | Follows 1.5A approval | ✅ Complete |
+| 18 | HTTPS + Android validation execution | Active validation follow-up | Pending hardware access |
+| 19 | Branch C — Transliteration, morphology, linguistic inference | Only after users + data | Deferred |
+| 20 | Phase 6B — Consumer Search-First UX + Infrastructure Layering | UX/product milestone | ✅ Complete |
+| 21 | Phase 6D1 — Localization Architecture + French-First Interface Pass | Near-term consumer productization milestone | Implemented (pending review) |
 
-Phase 2.0 (Branch A) and the originally planned Phase 3 platform work have now served their purpose: the runtime proves bundle ingestion, IndexedDB storage, query execution, rendering, offline shell behavior, manifest-driven language metadata, installed bundle registry, active bundle selection, multi-bundle isolation, and catalog-driven install/update flows. The roadmap was previously lagging behind this implementation reality. Search/index quality is no longer a single undifferentiated pending bucket: **Phase 5a** is now treated as complete because `norm_v2` indexing has been implemented and validated, while **Phase 5b** is now substantially complete with Android real-device validation explicitly deferred until hardware access resumes. With that transition, **Phase 1.5A** (correction record schema/specification) and **Phase 1.5B** (dry-run correction application pipeline) are complete for backend dry-run scope, and **Phase 6B** is complete for consumer UX layering scope. UI/moderation workflows and committed correction-release lifecycle persistence remain intentionally out of scope for this completion state. Branch C remains explicitly deferred until real usage data exists.
+Phase 2.0 (Branch A) and the originally planned Phase 3 platform work have now served their purpose: the runtime proves bundle ingestion, IndexedDB storage, query execution, rendering, offline shell behavior, manifest-driven language metadata, installed bundle registry, active bundle selection, multi-bundle isolation, and catalog-driven install/update flows. The roadmap was previously lagging behind this implementation reality. Search/index quality is no longer a single undifferentiated pending bucket: **Phase 5** now includes **`norm_v2` phrase/index improvements** (Phase 5a) and **`norm_v3` NFC search-key canonicalization** as the successor default (see the Phase 5 section), while **Phase 5b** is now substantially complete with Android real-device validation explicitly deferred until hardware access resumes. With that transition, **Phase 1.5A** (correction record schema/specification) and **Phase 1.5B** (dry-run correction application pipeline) are complete for backend dry-run scope, and **Phase 6B** is complete for consumer UX layering scope. UI/moderation workflows and committed correction-release lifecycle persistence remain intentionally out of scope for this completion state. Branch C remains explicitly deferred until real usage data exists.
 
 ### Phase 6B — Consumer Search-First UX + Infrastructure Layering ✅
 
@@ -510,9 +511,9 @@ DoD:
 - Frontend runtime code no longer embeds a specific target language in its direction model.
 - Runtime search semantics enforce the selected direction instead of treating the toggle as display-only state.
 
-#### Phase 4.2.5 — Directional search semantics *(partially complete)*
+#### Phase 4.2.5 — Directional search semantics ✅
 
-This mini-phase makes the direction toggle real at query time without changing the normalized record schema.
+This mini-phase makes the direction toggle real at query time without changing the normalized record schema. *(It was introduced with Phase 3 platform work; the **non-hybrid** manifest/builder/runtime alignment was completed later — see Phase 5b, “Directional contract hardening”.)*
 
 Bundle contract:
 
@@ -534,21 +535,7 @@ Current bundle-generation mapping:
 - `index_mapping` records emit `src_*` keys from `fields_raw.source_term`
 - `lexicon_entry` records emit `tgt_*` keys from headword/variant normalization
 
-Current status:
-
-- directional `src_*` / `tgt_*` query execution is implemented
-- legacy fallback is still present for older bundles
-- the bundle-level capability flag is still not formalized in the typed manifest/runtime contract
-
-**Remaining future step: bundle-level capability flag**
-
-Right now the runtime tries the directional ladder first and falls back to the legacy (undirected) ladder only when the directional ladder returns zero results. That can create subtle ranking distortions later (e.g. directional bundle has a weak match, legacy fallback would have had a strong match → confusing ordering). To avoid hybrid logic:
-
-- Add a manifest flag, e.g. `search_index_directional: true`.
-- **If directional bundle** (flag true): never fallback; use only the directional ladder.
-- **If legacy bundle** (flag absent or false): always use the legacy ladder only; do not try directional keys.
-
-Then each bundle type has a single, predictable code path and no mixed ranking.
+**Status (Phase 5b-aligned):** The bundle manifest exposes **`search_index_directional`**. The builder and runtime use a **single ladder per bundle**: directional bundles (`search_index_directional: true`, including `norm_v2` / `norm_v3` publish paths) use **only** directional `src_*` / `tgt_*` keys; legacy bundles use **only** undirected key families. There is **no** cross-family fallback, so ordering stays predictable.
 
 ### Phase 3.3 — Installed bundle registry ✅
 
@@ -604,9 +591,7 @@ DoD:
 
 ## Phase 5 — Search/index quality improvement
 
-Phase 5 now has two parts: the indexing-quality upgrade that shipped as
-`norm_v2`, and the remaining contract/runtime hardening needed so directional
-search behavior is explicit and non-hybrid across bundle generations.
+Phase 5 covers **indexing rulesets** (`norm_v2`, then **`norm_v3`** as the successor normalizer default for new derived artifacts) and **Phase 5b** — field validation and search-reality calibration. **Directional search** is **fully explicit**: manifests carry **`search_index_directional`**, and the runtime uses a **single** ladder per bundle (directional `src_*` / `tgt_*` **or** legacy undirected keys only — **no hybrid fallback**). That contract alignment shipped as the Phase 5b “Directional contract hardening” subtask.
 
 ### Phase 5a — `norm_v2` indexing shipped ✅
 
@@ -632,6 +617,18 @@ Completion criteria now satisfied:
   generation
 - `norm_v2` remains explicit in derived artifacts and bundle metadata through
   `rule_versions.normalization`
+
+### `norm_v3` — NFC search-key canonicalization (successor default) ✅
+
+**Status:** Implemented. The normalizer’s active ruleset is **`norm_v3`**, which
+preserves the full **`norm_v2`** variant and phrase-extraction contract and adds
+**NFC preprocessing** of search-key input forms so composed and decomposed
+Unicode spellings (e.g. `kùn` vs `kùn`) produce equivalent search-key material.
+Frozen **`norm_v1`** / historical **`norm_v2`** Python modules are unchanged; new
+builds stamp `norm_version: "norm_v3"` and manifest
+`rule_versions.normalization: "norm_v3"`. Directional `src_*` / `tgt_*` bundles
+behave like `norm_v2` from the runtime’s perspective (unchanged
+`searchQuery` + ladder).
 
 ### Phase 5b — Field Validation + Search Reality Calibration
 
@@ -664,7 +661,7 @@ Capture the following per query:
 - `ir_ids_count`
 - `bundle_id`
 - `bundle_version` (from manifest)
-- `norm_version` (`norm_v1` / `norm_v2`)
+- `norm_version` (`norm_v1` / `norm_v2` / `norm_v3`)
 - `app_version` (build identifier)
 - `timestamp`
 - `logging_enabled` (boolean)
@@ -713,7 +710,7 @@ Define the cycle:
    - phrase extraction
    - normalization rules
    - index coverage
-5. Rebuild bundle (future `norm_v3`)
+5. Rebuild normalized JSONL, search index, and bundle under the appropriate `norm_vN` — for example, a refreshed `norm_v3` build, or a future `norm_v4+` only when a new ruleset change is justified.
 
 No runtime AI involvement.
 

--- a/shared/normalization/norm_v3.py
+++ b/shared/normalization/norm_v3.py
@@ -1,0 +1,49 @@
+"""
+Normalization ruleset norm_v3.
+
+norm_v3 preserves the full norm_v2 contract (variant expansion + phrase extraction)
+and adds exactly one semantic change:
+
+  Before applying the norm_v1 per-string key transforms, each search-key input
+  form is whitespace-normalized, then NFC-canonicalized.
+
+Historical norm_v1 and norm_v2 modules are not modified by this ruleset; norm_v3
+composes them.
+"""
+
+from __future__ import annotations
+
+from .norm_v1 import compute_search_keys as _compute_search_keys_v1
+from .norm_v1 import normalize_nfc, normalize_whitespace
+from .norm_v2 import (
+    MAX_SOURCE_PHRASES,
+    MAX_SOURCE_SEGMENTS,
+    MIN_SOURCE_PHRASE_LENGTH,
+    SOURCE_STOPWORDS,
+    extract_source_phrases,
+)
+
+RULESET_ID = "norm_v3"
+
+
+def compute_search_keys(forms: list[str]) -> dict[str, list[str]]:
+    """
+    Derive search keys like norm_v1, after NFC-canonicalizing each input form.
+
+    Pipeline per form: normalize_whitespace → normalize_nfc → norm_v1 key ladder.
+    """
+    prepped = [normalize_nfc(normalize_whitespace(f)) for f in forms]
+    return _compute_search_keys_v1(prepped)
+
+
+__all__ = [
+    "RULESET_ID",
+    "compute_search_keys",
+    "extract_source_phrases",
+    "MAX_SOURCE_PHRASES",
+    "MAX_SOURCE_SEGMENTS",
+    "MIN_SOURCE_PHRASE_LENGTH",
+    "SOURCE_STOPWORDS",
+    "normalize_nfc",
+    "normalize_whitespace",
+]

--- a/shared/specs/normalization-versioning.md
+++ b/shared/specs/normalization-versioning.md
@@ -279,6 +279,26 @@ These rules are additive alias-generation only. They MUST NOT replace the
 stored original source string, and they MUST NOT silently rewrite frozen
 `norm_v1` outputs in place.
 
+## `norm_v3` Unicode search-key canonicalization
+
+`norm_v3` preserves the full **`norm_v2` contract** (same `extract_source_phrases`
+behavior, same `lexicon_entry` / `index_mapping` variant policies in the
+normalizer, same underlying per-string key transforms from `norm_v1`).
+
+**Semantic change (only):** before each variant form is passed into
+`norm_v1.compute_search_keys`, `norm_v3` applies:
+
+1. whitespace normalization (`normalize_whitespace`), then
+2. Unicode **NFC** (`normalize_nfc`).
+
+Display fields (`preferred_form`, `variant_forms` on normalized records) are
+**not** rewritten for NFC; only **search-key derivation inputs** are
+canonicalized. This makes NFC- and NFD-encoded **visually equivalent** strings
+produce identical search-key material and consistent ladder lookup.
+
+Historical `norm_v1` and `norm_v2` code modules remain unchanged; `norm_v3`
+composes them in `shared/normalization/norm_v3.py`.
+
 ## Minimal metadata contract (summary)
 
 Normalized records SHOULD be able to carry:

--- a/shared/specs/offline-bundle-versioning.md
+++ b/shared/specs/offline-bundle-versioning.md
@@ -80,7 +80,7 @@ Every bundle MUST include a manifest file (e.g., `bundle.manifest.json`) contain
   - `consumer_compat.min_record_schema_version`
   - `consumer_compat.min_app_version` (OPTIONAL)
 - **Rule versions (required)**
-  - `rule_versions.normalization` (e.g., `norm_v1`, `norm_v2`) — see `shared/specs/normalization-versioning.md`
+  - `rule_versions.normalization` (e.g., `norm_v1`, `norm_v2`, `norm_v3`) — see `shared/specs/normalization-versioning.md`
   - `rule_versions.transliteration` (e.g., `nko_translit_v1`) when applicable
   - `rule_versions.pos_mapping` (e.g., `posmap_v1`) when applicable
   - `rule_versions.url_canonicalization` (e.g., `urlcanon_v1`) when applicable

--- a/web/src/phase3_bundle_runtime.test.ts
+++ b/web/src/phase3_bundle_runtime.test.ts
@@ -113,6 +113,32 @@ describe("Phase 3 manifest parsing", () => {
     expect(result.manifest?.rule_versions.normalization).toBe("norm_v2");
   });
 
+  it("accepts norm_v3 normalization ruleset in manifests", () => {
+    const result = parseAndValidateManifestJson(
+      JSON.stringify({
+        manifest_schema_version: "bundle_manifest_v1",
+        bundle_id: "bundle_full_norm_v3_aaaaaaaa",
+        bundle_type: "full",
+        bundle_format: "directory",
+        compression: "none",
+        record_schema_id: "normalized_v1",
+        record_schema_version: "1",
+        rule_versions: { normalization: "norm_v3" },
+        sources: { included: ["src_malipense"], excluded: [] },
+        reconciliation_action: "REPLACE_ALL",
+        update_mode: "REPLACE_ALL",
+        files: [
+          { path: "records.jsonl", byte_length: 10, sha256: "sha256:aaa" },
+          { path: "search_index.jsonl", byte_length: 20, sha256: "sha256:bbb" },
+        ],
+        content_sha256: "sha256:ccc",
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.manifest?.rule_versions.normalization).toBe("norm_v3");
+  });
+
   it("parses search_index_directional when present", () => {
     const result = parseAndValidateManifestJson(
       JSON.stringify({
@@ -323,6 +349,111 @@ describe("Phase 3 bundle-aware runtime", () => {
 
       expect((await searchQuery(db, bundleId, "target_to_source", "bon travail", true)).ir_ids).toEqual([]);
       expect((await searchQuery(db, bundleId, "source_to_target", "ߘߊ߰", true)).ir_ids).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  /**
+   Unicode NFC canonicalization (norm_v3): index keys use NFC-composed Latin forms.
+   Unchanged searchQuery + normalizeNfc(query) must hit tgt_casefold "kùn" for both
+   composed and decomposed user input. Synthetic records mirror Python norm_v3 output.
+   */
+  it("resolves norm_v3 NFC-composed target keys with unchanged searchQuery", async () => {
+    const db = await openSiralexDb();
+    try {
+      const bundleId = "bundle_full_norm_v3_nfc_search";
+
+      const kunKeys = {
+        casefold: ["kùn"],
+        diacritics_insensitive: ["kun"],
+        punct_stripped: ["kun"],
+        nospace: ["kun"],
+      };
+      const teteKeys = {
+        casefold: ["tête"],
+        diacritics_insensitive: ["tete"],
+        punct_stripped: ["tete"],
+        nospace: ["tete"],
+      };
+      const senKeys = {
+        casefold: ["sen"],
+        diacritics_insensitive: ["sen"],
+        punct_stripped: ["sen"],
+        nospace: ["sen"],
+      };
+      const piedKeys = {
+        casefold: ["pied"],
+        diacritics_insensitive: ["pied"],
+        punct_stripped: ["pied"],
+        nospace: ["pied"],
+      };
+
+      await importRecordsJsonl(
+        db,
+        makeJsonlFile("records.jsonl", [
+          {
+            ir_id: "rec-map-tete",
+            ir_kind: "index_mapping",
+            source_id: "src_malipense",
+            norm_version: "norm_v3",
+            preferred_form: "tête",
+            variant_forms: ["tête"],
+            search_keys: teteKeys,
+            display: { source_term: "tête" },
+          },
+          {
+            ir_id: "rec-lex-kun",
+            ir_kind: "lexicon_entry",
+            source_id: "src_malipense",
+            norm_version: "norm_v3",
+            preferred_form: "ku\u0300n",
+            variant_forms: ["ku\u0300n"],
+            search_keys: kunKeys,
+            display: { headword_latin: "ku\u0300n" },
+          },
+          {
+            ir_id: "rec-map-pied",
+            ir_kind: "index_mapping",
+            source_id: "src_malipense",
+            norm_version: "norm_v3",
+            preferred_form: "pied",
+            variant_forms: ["pied"],
+            search_keys: piedKeys,
+            display: { source_term: "pied" },
+          },
+          {
+            ir_id: "rec-lex-sen",
+            ir_kind: "lexicon_entry",
+            source_id: "src_malipense",
+            norm_version: "norm_v3",
+            preferred_form: "sen",
+            variant_forms: ["sen"],
+            search_keys: senKeys,
+            display: { headword_latin: "sen" },
+          },
+        ]),
+        { bundleId, batchSize: 10 },
+      );
+      await importSearchIndexJsonl(
+        db,
+        makeJsonlFile("search_index.jsonl", [
+          { key_type: "src_casefold", key: "tête", ir_ids: ["rec-map-tete"] },
+          { key_type: "tgt_casefold", key: "kùn", ir_ids: ["rec-lex-kun"] },
+          { key_type: "src_casefold", key: "pied", ir_ids: ["rec-map-pied"] },
+          { key_type: "tgt_casefold", key: "sen", ir_ids: ["rec-lex-sen"] },
+        ]),
+        { bundleId, batchSize: 10 },
+      );
+
+      expect((await searchQuery(db, bundleId, "source_to_target", "tête", true)).ir_ids).toEqual(["rec-map-tete"]);
+      expect((await searchQuery(db, bundleId, "source_to_target", "te\u0302te", true)).ir_ids).toEqual(["rec-map-tete"]);
+
+      expect((await searchQuery(db, bundleId, "target_to_source", "Kùn", true)).ir_ids).toEqual(["rec-lex-kun"]);
+      expect((await searchQuery(db, bundleId, "target_to_source", "ku\u0300n", true)).ir_ids).toEqual(["rec-lex-kun"]);
+
+      expect((await searchQuery(db, bundleId, "source_to_target", "pied", true)).ir_ids).toEqual(["rec-map-pied"]);
+      expect((await searchQuery(db, bundleId, "target_to_source", "Sen", true)).ir_ids).toEqual(["rec-lex-sen"]);
     } finally {
       db.close();
     }


### PR DESCRIPTION
Introduce norm_v3 as norm_v2 plus whitespace+NFC preprocessing before norm_v1 key transforms; wire normalizer and directional bundle builder; add Python and web integration tests. Document ruleset, roadmap (including Phase 4.2.5/Phase 5 directional status and norm_v3 ordering row), and BUILD_BUNDLE placeholder paths for frozen v1 vs successor artifacts.

## What does this PR change?

- 

## Why?

- 

## Checklist (required)

- [ ] I kept this PR narrowly scoped.
- [ ] If I changed language data / meaning, I explained the impact and any uncertainty.
- [ ] If this touches third-party sources, I preserved attribution and did not add content without permission.
- [ ] If this changes normalization/transliteration behavior, I added examples (inputs → outputs) in the PR description.

## Screenshots / notes (if applicable)

- 

